### PR TITLE
Create SymptomsQA component and add mock question data

### DIFF
--- a/components/GroupMultipleQ.js
+++ b/components/GroupMultipleQ.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { Body, Card, CardItem, Input, Item } from 'native-base';
+import { CheckBox } from 'react-native-elements';
+
+const height = Dimensions.get('window').height;
+
+export default function GroupMultipleQ({ question }) {
+  return (
+    <Card id={question.question.items[0].id} style={styles.questionCard}>
+      <Body>
+        <Text style={styles.questionText}>{question.question.text}</Text>
+        <CardItem style={styles.questionCardItem}>
+          <Body>
+            <Text style={styles.questionText}>
+              {question.question.items[0].name}
+            </Text>
+            <View style={styles.checkboxes}>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[0].id}
+                title={
+                  <Text>{question.question.items[0].choices[0].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[1].id}
+                title={
+                  <Text>{question.question.items[0].choices[1].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[2].id}
+                title={
+                  <Text>{question.question.items[0].choices[2].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+            </View>
+          </Body>
+        </CardItem>
+        <CardItem style={styles.questionCardItem}>
+          <Body>
+            <Text style={styles.questionText}>
+              {question.question.items[1].name}
+            </Text>
+            <View style={styles.checkboxes}>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[0].id}
+                title={
+                  <Text>{question.question.items[1].choices[0].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[1].id}
+                title={
+                  <Text>{question.question.items[1].choices[1].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[2].id}
+                title={
+                  <Text>{question.question.items[1].choices[2].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+            </View>
+          </Body>
+        </CardItem>
+      </Body>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  questionCard: {
+    flex: 0.65,
+    marginBottom: height * 0.01,
+    marginTop: height * 0.01,
+    width: '80%'
+  },
+  questionCardItem: {
+    height: height * 0.15
+  },
+  questionText: {
+    alignSelf: 'flex-start',
+    flex: 1,
+    fontSize: 16,
+    padding: 0
+  },
+  checkboxes: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    fontSize: 12,
+    padding: 0
+  }
+});

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { Body, Card, CardItem, Input, Item } from 'native-base';
+import { CheckBox } from 'react-native-elements';
+
+const height = Dimensions.get('window').height;
+
+export default function GroupSingleQ({ question }) {
+  return (
+    <Card id={question.question.items[0].id} style={styles.questionCard}>
+      <Body>
+        <Text style={styles.questionText}>{question.question.text}</Text>
+        <CardItem style={styles.questionCardItem}>
+          <Body>
+            <Text style={styles.questionText}>
+              {question.question.items[0].name}
+            </Text>
+            <View style={styles.checkboxes}>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[0].id}
+                title={
+                  <Text>{question.question.items[0].choices[0].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[1].id}
+                title={
+                  <Text>{question.question.items[0].choices[1].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[0].choices[2].id}
+                title={
+                  <Text>{question.question.items[0].choices[2].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+            </View>
+          </Body>
+        </CardItem>
+        <CardItem style={styles.questionCardItem}>
+          <Body>
+            <Text style={styles.questionText}>
+              {question.question.items[1].name}
+            </Text>
+            <View style={styles.checkboxes}>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[0].id}
+                title={
+                  <Text>{question.question.items[1].choices[0].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[1].id}
+                title={
+                  <Text>{question.question.items[1].choices[1].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[2].id}
+                title={
+                  <Text>{question.question.items[1].choices[2].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+            </View>
+          </Body>
+        </CardItem>
+        <CardItem style={styles.questionCardItem}>
+          <Body>
+            <Text style={styles.questionText}>
+              {question.question.items[2].name}
+            </Text>
+            <View style={styles.checkboxes}>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[0].id}
+                title={
+                  <Text>{question.question.items[1].choices[0].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[1].id}
+                title={
+                  <Text>{question.question.items[1].choices[1].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+              <CheckBox
+                center
+                id={question.question.items[1].choices[2].id}
+                title={
+                  <Text>{question.question.items[1].choices[2].label}</Text>
+                }
+                // checked={}
+                // onPress={}
+              ></CheckBox>
+            </View>
+          </Body>
+        </CardItem>
+      </Body>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  questionCard: {
+    flex: 0.65,
+    marginBottom: height * 0.01,
+    marginTop: height * 0.01,
+    width: '80%'
+  },
+  questionCardItem: {
+    height: height * 0.15
+  },
+  questionText: {
+    alignSelf: 'flex-start',
+    flex: 1,
+    fontSize: 16,
+    padding: 0
+  },
+  checkboxes: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    fontSize: 12,
+    padding: 0
+  }
+});

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { Body, Card, CardItem, Input, Item } from 'native-base';
+import { CheckBox } from 'react-native-elements';
+
+const height = Dimensions.get('window').height;
+
+export default function SingleQ({ question }) {
+  return (
+    <Card id={question.question.items[0].id} style={styles.questionCard}>
+      <CardItem style={styles.questionCardItem}>
+        <Body>
+          <Text style={styles.questionText}>{question.question.text}</Text>
+          <View style={styles.checkboxes}>
+            <CheckBox
+              center
+              id={question.question.items[0].choices[0].id}
+              title={<Text>{question.question.items[0].choices[0].label}</Text>}
+              // checked={}
+              // onPress={}
+            ></CheckBox>
+            <CheckBox
+              center
+              id={question.question.items[0].choices[1].id}
+              title={<Text>{question.question.items[0].choices[1].label}</Text>}
+              // checked={}
+              // onPress={}
+            ></CheckBox>
+            <CheckBox
+              center
+              id={question.question.items[0].choices[2].id}
+              title={<Text>{question.question.items[0].choices[2].label}</Text>}
+              // checked={}
+              // onPress={}
+            ></CheckBox>
+          </View>
+        </Body>
+      </CardItem>
+    </Card>
+  );
+}
+
+const styles = {
+  questionCard: {
+    marginBottom: height * 0.01,
+    marginTop: height * 0.01,
+    width: '80%'
+  },
+  questionCardItem: {
+    height: height * 0.15
+  },
+  questionText: {
+    alignSelf: 'flex-start',
+    flex: 1,
+    fontSize: 16,
+    padding: 0
+  },
+  checkboxes: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    fontSize: 12,
+    padding: 0
+  }
+};

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -40,7 +40,7 @@ export default function SingleQ({ question }) {
   );
 }
 
-const styles = {
+const styles = StyleSheet.create({
   questionCard: {
     marginBottom: height * 0.01,
     marginTop: height * 0.01,
@@ -61,4 +61,4 @@ const styles = {
     fontSize: 12,
     padding: 0
   }
-};
+});

--- a/navigation/AppContainer.js
+++ b/navigation/AppContainer.js
@@ -22,7 +22,7 @@ const RootStack = createStackNavigator(
     SymptomsQA
   },
   {
-    initialRouteName: 'SymptomsQA',
+    initialRouteName: 'BiologicalInformation',
     transitionConfig: () => fromBottom(),
     headerMode: 'none',
     navigationOptions: {

--- a/navigation/AppContainer.js
+++ b/navigation/AppContainer.js
@@ -22,7 +22,7 @@ const RootStack = createStackNavigator(
     SymptomsQA
   },
   {
-    initialRouteName: 'BiologicalInformation',
+    initialRouteName: 'Welcome',
     transitionConfig: () => fromBottom(),
     headerMode: 'none',
     navigationOptions: {

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -46,16 +46,16 @@ export default function SymptomsScreen({ navigation }) {
     const userInfo = { age, presentFactors, symptomIds, sex };
     try {
       let cleanedData = await cleanInitialUserReport(userInfo);
-      let symptomFollowup = await sendInitialUserSymptoms(cleanedData);
+      // let symptomFollowup = await sendInitialUserSymptoms(cleanedData);
       navigation.navigate('SymptomsQA', {
         age,
         location,
         presentFactors,
         sex,
-        symptomFollowup
+        // symptomFollowup
       });
-      console.log('symptom follow up?', symptomFollowup);
-      return symptomFollowup;
+      // console.log('symptom follow up?', symptomFollowup);
+      // return symptomFollowup;
     } catch (error) {
       throw new Error(error);
     }

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -46,16 +46,16 @@ export default function SymptomsScreen({ navigation }) {
     const userInfo = { age, presentFactors, symptomIds, sex };
     try {
       let cleanedData = await cleanInitialUserReport(userInfo);
-      // let symptomFollowup = await sendInitialUserSymptoms(cleanedData);
+      let symptomFollowup = await sendInitialUserSymptoms(cleanedData);
       navigation.navigate('SymptomsQA', {
         age,
         location,
         presentFactors,
         sex,
-        // symptomFollowup
+        symptomFollowup
       });
-      // console.log('symptom follow up?', symptomFollowup);
-      // return symptomFollowup;
+      console.log('symptom follow up?', symptomFollowup);
+      return symptomFollowup;
     } catch (error) {
       throw new Error(error);
     }

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { Body, Card, CardItem, Input, Item } from 'native-base';
 import { CheckBox } from 'react-native-elements';
-import { Entypo, FontAwesome } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollView } from 'react-native-gesture-handler';
 
@@ -11,7 +11,7 @@ const height = Dimensions.get('window').height;
 export default function SymptomsQA({ navigation }) {
   // const { age, location, presentFactors, sex, symptomFollowup } = navigation.state.params;
   // const [currentQuestion, setCurrentQuestion] = useState({})
-  const mockData = {
+  const mockGroupSingle = {
     conditions: [
       {
         common_name: 'Gastroenteritis',
@@ -115,6 +115,132 @@ export default function SymptomsQA({ navigation }) {
     should_stop: false
   };
 
+  const mockSingle = {
+    extras: {},
+    question: {
+      extras: {},
+      items: [
+        {
+          choices: [
+            {
+              id: 'present',
+              label: 'Yes'
+            },
+            {
+              id: 'absent',
+              label: 'No'
+            },
+            {
+              id: 'unknown',
+              label: "Don't know"
+            }
+          ],
+          id: 's_1933',
+          name: 'Hypertension, over 180 mmHg'
+        }
+      ],
+      text:
+        'Was your systolic pressure greater than 180 mmHg, or diastolic pressure greater than 120 mmHg?',
+      type: 'single'
+    },
+    conditions: [
+      {
+        common_name: 'Chronic venous insufficiency',
+        id: 'c_84',
+        name: 'Chronic venous insufficiency',
+        probability: 0.6648
+      },
+      {
+        common_name: 'Dilated cardiomyopathy',
+        id: 'c_759',
+        name: 'Dilated cardiomyopathy',
+        probability: 0.3285
+      },
+      {
+        common_name: 'Chronic kidney disease',
+        id: 'c_180',
+        name: 'Chronic kidney disease',
+        probability: 0.2801
+      },
+      {
+        common_name: 'Nephrotic syndrome',
+        id: 'c_265',
+        name: 'Nephrotic syndrome',
+        probability: 0.2738
+      },
+      {
+        common_name: 'Right-sided heart failure',
+        id: 'c_572',
+        name: 'Right-sided heart failure',
+        probability: 0.2701
+      },
+      {
+        common_name: 'Henoch-Schönlein purpura',
+        id: 'c_463',
+        name: 'Henoch-Schönlein purpura',
+        probability: 0.1579
+      },
+      {
+        common_name: 'Biventricular heart failure',
+        id: 'c_612',
+        name: 'Biventricular heart failure',
+        probability: 0.1574
+      }
+    ],
+    should_stop: false
+  };
+
+  const mockGroupMultiple = {
+    question: {
+      type: 'group_multiple',
+      text: 'Do you experience any of the following problems with breathing?',
+      items: [
+        {
+          id: 's_2075',
+          name: 'Sudden difficulty breathing or shortness of breath',
+          choices: [
+            { id: 'present', label: 'Yes' },
+            { id: 'absent', label: 'No' },
+            { id: 'unknown', label: "Don't know" }
+          ]
+        },
+        {
+          id: 's_2076',
+          name:
+            'Rapid and shallow breathing, wheezing or bluish skin coloration',
+          choices: [
+            { id: 'present', label: 'Yes' },
+            { id: 'absent', label: 'No' },
+            { id: 'unknown', label: "Don't know" }
+          ]
+        }
+      ],
+      extras: {}
+    },
+    conditions: [
+      {
+        id: 'c_899',
+        name: 'Cervical acceleration-deceleration syndrome',
+        common_name: 'Whiplash injury',
+        probability: 0.9179
+      },
+      {
+        id: 'c_49',
+        name: 'Migraine',
+        common_name: 'Migraine',
+        probability: 0.4116
+      },
+      {
+        id: 'c_563',
+        name: 'Bacterial meningitis',
+        common_name: 'Bacterial meningitis',
+        probability: 0.1845
+      }
+    ],
+    extras: {},
+    should_stop: true
+  };
+
   return (
     <View style={styles.container}>
       <LinearGradient
@@ -122,8 +248,22 @@ export default function SymptomsQA({ navigation }) {
         colors={['#004EFF', '#88CCF1']}
       >
         <View style={styles.contentContainer}>
+          <Entypo
+            name='chevron-thin-up'
+            size={36}
+            color='white'
+            onPress={() => navigation.navigate('SearchSymptoms')}
+          />
           <Text style={styles.symptomText}>Regarding your symptoms:</Text>
-          <Text style={styles.symptomText}>{mockData.question.text}</Text>
+          <Text style={styles.symptomText}>
+            {mockGroupSingle.question.text}
+          </Text>
+          <Entypo
+            name='chevron-thin-down'
+            size={36}
+            color='white'
+            // onPress={() => }
+          />
         </View>
       </LinearGradient>
     </View>

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -6,241 +6,19 @@ import { Entypo } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollView } from 'react-native-gesture-handler';
 import SingleQ from '../../components/SingleQ';
+import GroupSingleQ from '../../components/GroupSingleQ';
+import GroupMultipleQ from '../../components/GroupMultipleQ';
+import {
+  mockSingle,
+  mockGroupMultiple,
+  mockGroupSingle
+} from '../../utils/mockQuestions/mockQuestions';
 
 const height = Dimensions.get('window').height;
 
 export default function SymptomsQA({ navigation }) {
   // const { age, location, presentFactors, sex, symptomFollowup } = navigation.state.params;
   // const [currentQuestion, setCurrentQuestion] = useState({})
-  const mockGroupSingle = {
-    conditions: [
-      {
-        common_name: 'Gastroenteritis',
-        id: 'c_10',
-        name: 'Gastroenteritis',
-        probability: 0.3477
-      },
-      {
-        common_name: 'Food poisoning',
-        id: 'c_138',
-        name: 'Food poisoning',
-        probability: 0.2861
-      },
-      {
-        common_name: 'Irritable bowel',
-        id: 'c_142',
-        name: 'Irritable bowel syndrome',
-        probability: 0.2477
-      },
-      {
-        common_name: 'Abdominal pain, unspecified',
-        id: 'c_969',
-        name: 'Abdominal pain, unspecified',
-        probability: 0.1785
-      },
-      {
-        common_name: 'Gastritis',
-        id: 'c_515',
-        name: 'Gastritis',
-        probability: 0.1542
-      },
-      {
-        common_name: 'Stomach ulcer',
-        id: 'c_20',
-        name: 'Peptic ulcer',
-        probability: 0.1189
-      }
-    ],
-    extras: {},
-    question: {
-      extras: {},
-      items: [
-        {
-          choices: [
-            {
-              id: 'present',
-              label: 'Yes'
-            },
-            {
-              id: 'absent',
-              label: 'No'
-            },
-            {
-              id: 'unknown',
-              label: "Don't know"
-            }
-          ],
-          id: 's_1782',
-          name: 'Mild'
-        },
-        {
-          choices: [
-            {
-              id: 'present',
-              label: 'Yes'
-            },
-            {
-              id: 'absent',
-              label: 'No'
-            },
-            {
-              id: 'unknown',
-              label: "Don't know"
-            }
-          ],
-          id: 's_1783',
-          name: 'Moderate'
-        },
-        {
-          choices: [
-            {
-              id: 'present',
-              label: 'Yes'
-            },
-            {
-              id: 'absent',
-              label: 'No'
-            },
-            {
-              id: 'unknown',
-              label: "Don't know"
-            }
-          ],
-          id: 's_1195',
-          name: 'Severe'
-        }
-      ],
-      text: 'How strong is your abdominal pain?',
-      type: 'group_single'
-    },
-    should_stop: false
-  };
-
-  const mockSingle = {
-    extras: {},
-    question: {
-      extras: {},
-      items: [
-        {
-          choices: [
-            {
-              id: 'present',
-              label: 'Yes'
-            },
-            {
-              id: 'absent',
-              label: 'No'
-            },
-            {
-              id: 'unknown',
-              label: "Don't know"
-            }
-          ],
-          id: 's_1933',
-          name: 'Hypertension, over 180 mmHg'
-        }
-      ],
-      text:
-        'Was your systolic pressure greater than 180 mmHg, or diastolic pressure greater than 120 mmHg?',
-      type: 'single'
-    },
-    conditions: [
-      {
-        common_name: 'Chronic venous insufficiency',
-        id: 'c_84',
-        name: 'Chronic venous insufficiency',
-        probability: 0.6648
-      },
-      {
-        common_name: 'Dilated cardiomyopathy',
-        id: 'c_759',
-        name: 'Dilated cardiomyopathy',
-        probability: 0.3285
-      },
-      {
-        common_name: 'Chronic kidney disease',
-        id: 'c_180',
-        name: 'Chronic kidney disease',
-        probability: 0.2801
-      },
-      {
-        common_name: 'Nephrotic syndrome',
-        id: 'c_265',
-        name: 'Nephrotic syndrome',
-        probability: 0.2738
-      },
-      {
-        common_name: 'Right-sided heart failure',
-        id: 'c_572',
-        name: 'Right-sided heart failure',
-        probability: 0.2701
-      },
-      {
-        common_name: 'Henoch-Schönlein purpura',
-        id: 'c_463',
-        name: 'Henoch-Schönlein purpura',
-        probability: 0.1579
-      },
-      {
-        common_name: 'Biventricular heart failure',
-        id: 'c_612',
-        name: 'Biventricular heart failure',
-        probability: 0.1574
-      }
-    ],
-    should_stop: false
-  };
-
-  const mockGroupMultiple = {
-    question: {
-      type: 'group_multiple',
-      text: 'Do you experience any of the following problems with breathing?',
-      items: [
-        {
-          id: 's_2075',
-          name: 'Sudden difficulty breathing or shortness of breath',
-          choices: [
-            { id: 'present', label: 'Yes' },
-            { id: 'absent', label: 'No' },
-            { id: 'unknown', label: "Don't know" }
-          ]
-        },
-        {
-          id: 's_2076',
-          name:
-            'Rapid and shallow breathing, wheezing or bluish skin coloration',
-          choices: [
-            { id: 'present', label: 'Yes' },
-            { id: 'absent', label: 'No' },
-            { id: 'unknown', label: "Don't know" }
-          ]
-        }
-      ],
-      extras: {}
-    },
-    conditions: [
-      {
-        id: 'c_899',
-        name: 'Cervical acceleration-deceleration syndrome',
-        common_name: 'Whiplash injury',
-        probability: 0.9179
-      },
-      {
-        id: 'c_49',
-        name: 'Migraine',
-        common_name: 'Migraine',
-        probability: 0.4116
-      },
-      {
-        id: 'c_563',
-        name: 'Bacterial meningitis',
-        common_name: 'Bacterial meningitis',
-        probability: 0.1845
-      }
-    ],
-    extras: {},
-    should_stop: true
-  };
 
   return (
     <View style={styles.container}>
@@ -256,10 +34,12 @@ export default function SymptomsQA({ navigation }) {
             onPress={() => navigation.navigate('SearchSymptoms')}
           />
           <Text style={styles.symptomText}>Regarding your symptoms:</Text>
-          <Text style={styles.symptomText}>
-            {mockGroupSingle.question.text}
-          </Text>
-          <SingleQ style={styles.question} question={mockSingle} />
+          {/* <SingleQ style={styles.question} question={mockSingle} /> */}
+          {/* <GroupSingleQ style={styles.question} question={mockGroupSingle} /> */}
+          <GroupMultipleQ
+            style={styles.question}
+            question={mockGroupMultiple}
+          />
           <Entypo
             name='chevron-thin-down'
             size={36}
@@ -272,7 +52,7 @@ export default function SymptomsQA({ navigation }) {
   );
 }
 
-const styles = {
+const styles = StyleSheet.create({
   gradientBackground: {
     alignItems: 'center',
     flex: 1
@@ -297,4 +77,4 @@ const styles = {
   question: {
     width: '80%'
   }
-};
+});

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -5,6 +5,7 @@ import { CheckBox } from 'react-native-elements';
 import { Entypo } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollView } from 'react-native-gesture-handler';
+import SingleQ from '../../components/SingleQ';
 
 const height = Dimensions.get('window').height;
 
@@ -258,6 +259,7 @@ export default function SymptomsQA({ navigation }) {
           <Text style={styles.symptomText}>
             {mockGroupSingle.question.text}
           </Text>
+          <SingleQ style={styles.question} question={mockSingle} />
           <Entypo
             name='chevron-thin-down'
             size={36}
@@ -291,5 +293,8 @@ const styles = {
     alignSelf: 'flex-start',
     fontSize: 16,
     padding: 0
+  },
+  question: {
+    width: '80%'
   }
 };

--- a/utils/mockQuestions/mockQuestions.js
+++ b/utils/mockQuestions/mockQuestions.js
@@ -1,0 +1,228 @@
+export const mockGroupSingle = {
+  conditions: [
+    {
+      common_name: 'Gastroenteritis',
+      id: 'c_10',
+      name: 'Gastroenteritis',
+      probability: 0.3477
+    },
+    {
+      common_name: 'Food poisoning',
+      id: 'c_138',
+      name: 'Food poisoning',
+      probability: 0.2861
+    },
+    {
+      common_name: 'Irritable bowel',
+      id: 'c_142',
+      name: 'Irritable bowel syndrome',
+      probability: 0.2477
+    },
+    {
+      common_name: 'Abdominal pain, unspecified',
+      id: 'c_969',
+      name: 'Abdominal pain, unspecified',
+      probability: 0.1785
+    },
+    {
+      common_name: 'Gastritis',
+      id: 'c_515',
+      name: 'Gastritis',
+      probability: 0.1542
+    },
+    {
+      common_name: 'Stomach ulcer',
+      id: 'c_20',
+      name: 'Peptic ulcer',
+      probability: 0.1189
+    }
+  ],
+  extras: {},
+  question: {
+    extras: {},
+    items: [
+      {
+        choices: [
+          {
+            id: 'present',
+            label: 'Yes'
+          },
+          {
+            id: 'absent',
+            label: 'No'
+          },
+          {
+            id: 'unknown',
+            label: "Don't know"
+          }
+        ],
+        id: 's_1782',
+        name: 'Mild'
+      },
+      {
+        choices: [
+          {
+            id: 'present',
+            label: 'Yes'
+          },
+          {
+            id: 'absent',
+            label: 'No'
+          },
+          {
+            id: 'unknown',
+            label: "Don't know"
+          }
+        ],
+        id: 's_1783',
+        name: 'Moderate'
+      },
+      {
+        choices: [
+          {
+            id: 'present',
+            label: 'Yes'
+          },
+          {
+            id: 'absent',
+            label: 'No'
+          },
+          {
+            id: 'unknown',
+            label: "Don't know"
+          }
+        ],
+        id: 's_1195',
+        name: 'Severe'
+      }
+    ],
+    text: 'How strong is your abdominal pain?',
+    type: 'group_single'
+  },
+  should_stop: false
+};
+
+export const mockSingle = {
+  extras: {},
+  question: {
+    extras: {},
+    items: [
+      {
+        choices: [
+          {
+            id: 'present',
+            label: 'Yes'
+          },
+          {
+            id: 'absent',
+            label: 'No'
+          },
+          {
+            id: 'unknown',
+            label: "Don't know"
+          }
+        ],
+        id: 's_1933',
+        name: 'Hypertension, over 180 mmHg'
+      }
+    ],
+    text:
+      'Was your systolic pressure greater than 180 mmHg, or diastolic pressure greater than 120 mmHg?',
+    type: 'single'
+  },
+  conditions: [
+    {
+      common_name: 'Chronic venous insufficiency',
+      id: 'c_84',
+      name: 'Chronic venous insufficiency',
+      probability: 0.6648
+    },
+    {
+      common_name: 'Dilated cardiomyopathy',
+      id: 'c_759',
+      name: 'Dilated cardiomyopathy',
+      probability: 0.3285
+    },
+    {
+      common_name: 'Chronic kidney disease',
+      id: 'c_180',
+      name: 'Chronic kidney disease',
+      probability: 0.2801
+    },
+    {
+      common_name: 'Nephrotic syndrome',
+      id: 'c_265',
+      name: 'Nephrotic syndrome',
+      probability: 0.2738
+    },
+    {
+      common_name: 'Right-sided heart failure',
+      id: 'c_572',
+      name: 'Right-sided heart failure',
+      probability: 0.2701
+    },
+    {
+      common_name: 'Henoch-Schönlein purpura',
+      id: 'c_463',
+      name: 'Henoch-Schönlein purpura',
+      probability: 0.1579
+    },
+    {
+      common_name: 'Biventricular heart failure',
+      id: 'c_612',
+      name: 'Biventricular heart failure',
+      probability: 0.1574
+    }
+  ],
+  should_stop: false
+};
+
+export const mockGroupMultiple = {
+  question: {
+    type: 'group_multiple',
+    text: 'Do you experience any of the following problems with breathing?',
+    items: [
+      {
+        id: 's_2075',
+        name: 'Sudden difficulty breathing or shortness of breath',
+        choices: [
+          { id: 'present', label: 'Yes' },
+          { id: 'absent', label: 'No' },
+          { id: 'unknown', label: "Don't know" }
+        ]
+      },
+      {
+        id: 's_2076',
+        name: 'Rapid and shallow breathing, wheezing or bluish skin coloration',
+        choices: [
+          { id: 'present', label: 'Yes' },
+          { id: 'absent', label: 'No' },
+          { id: 'unknown', label: "Don't know" }
+        ]
+      }
+    ],
+    extras: {}
+  },
+  conditions: [
+    {
+      id: 'c_899',
+      name: 'Cervical acceleration-deceleration syndrome',
+      common_name: 'Whiplash injury',
+      probability: 0.9179
+    },
+    {
+      id: 'c_49',
+      name: 'Migraine',
+      common_name: 'Migraine',
+      probability: 0.4116
+    },
+    {
+      id: 'c_563',
+      name: 'Bacterial meningitis',
+      common_name: 'Bacterial meningitis',
+      probability: 0.1845
+    }
+  ],
+  extras: {},
+  should_stop: true
+};


### PR DESCRIPTION
## What does this PR do?
This PR adds mock data to the new SymptomsQA component so we can begin figuring out how to render the three different types of question formats: `single`, `group_single`, and `group_multiple` _without_ maxing out the infermedica API requests during development.
### Where should the reviewer start?
In `SymptomsQA.js` I have set up the very basic return statement with a hardcoded render for one of the question types (at a time, the other two are commented out). I want to talk to you about how we want to best navigate this, perhaps a switch statement? I have built out rough components for the three question types based upon sample data from fetch requests I have made. `However`, the components are not dynamic, and could use refactoring to iterate through the items array to ensure no question is missed. I will work on that tomorrow or Friday, unless you would like to work on it. Let me know. No checked state is being set.
### How should this be manually tested?
Open the app, answer the questions, and navigate to the SymptomsQA screen while keeping an eye on your terminal for the console.log
#### Have tests been written for all functionality?
No.
### Any background context you want to provide?
Infermedica needs sex, age and symptoms, but to avoid an error, please also fill out location (we don't have any "if this is empty, don't navigate" logic currently implemented)
### What are the relevant tickets?
#8 #33 
### Screenshots (if appropriate)
<img width="335" alt="Screen Shot 2020-01-01 at 9 46 45 PM" src="https://user-images.githubusercontent.com/31895658/71651778-e6d3e200-2ce5-11ea-8afb-f9bbd186be6a.png">
<img width="335" alt="Screen Shot 2020-01-02 at 2 22 27 AM" src="https://user-images.githubusercontent.com/31895658/71657775-e8fa6880-2d06-11ea-8dbe-4e34b5b59d4a.png">
<img width="335" alt="Screen Shot 2020-01-02 at 2 23 12 AM" src="https://user-images.githubusercontent.com/31895658/71657776-e8fa6880-2d06-11ea-9e5f-9e9dde5249fc.png">
<img width="335" alt="Screen Shot 2020-01-02 at 2 23 01 AM" src="https://user-images.githubusercontent.com/31895658/71657777-e8fa6880-2d06-11ea-974c-bb7d1dee9397.png">


### Additional Notes

🚨**Please merge pull request #56, then #57 first** 🚨
Can we talk before meeting on Saturday?