### PR TITLE
Add initial Doctors and Email screen components

### DIFF
--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -17,7 +17,6 @@ export default function GroupSingleQ({ question, answerQuestion }) {
         </Text>
         <View style={styles.checkboxes}>
           {item.choices.map((choice, checkBoxIndex) => {
-            console.log(checkWho)
             return <CheckBox
               key={checkBoxIndex}
               center
@@ -47,7 +46,6 @@ export default function GroupSingleQ({ question, answerQuestion }) {
         choice_id: checkWho[index]
       }
     })
-    console.log('response', response)
     setCheckWho([])
     answerQuestion(response);
   }

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -6,10 +6,7 @@ import { CheckBox } from 'react-native-elements';
 const height = Dimensions.get('window').height;
 
 export default function SingleQ({ question, answerQuestion }) {
-
   const [checkWho, setCheckWho] = useState([]);
-
-  useEffect(() => { console.log(checkWho) }, [checkWho])
 
   const handleSubmit = () => {
     answerQuestion([{

--- a/navigation/AppContainer.js
+++ b/navigation/AppContainer.js
@@ -10,6 +10,7 @@ import RiskFactors from '../screens/RiskFactors/RiskFactors';
 import SearchSymptoms from '../screens/SearchSymptoms/SearchSymptoms';
 import SymptomsQA from '../screens/SymptomsQA/SymptomsQA';
 import Results from '../screens/Results/Results';
+import DoctorsScreen from '../screens/DoctorsScreen/DoctorsScreen';
 
 const RootStack = createStackNavigator(
   {
@@ -21,7 +22,8 @@ const RootStack = createStackNavigator(
     RiskFactors: RiskFactors,
     SearchSymptoms: SearchSymptoms,
     SymptomsQA,
-    Results
+    Results,
+    Doctors: DoctorsScreen
   },
   {
     initialRouteName: 'Welcome',

--- a/navigation/AppContainer.js
+++ b/navigation/AppContainer.js
@@ -11,6 +11,7 @@ import SearchSymptoms from '../screens/SearchSymptoms/SearchSymptoms';
 import SymptomsQA from '../screens/SymptomsQA/SymptomsQA';
 import Results from '../screens/Results/Results';
 import DoctorsScreen from '../screens/DoctorsScreen/DoctorsScreen';
+import EmailScreen from '../screens/EmailScreen/EmailScreen';
 
 const RootStack = createStackNavigator(
   {
@@ -23,7 +24,8 @@ const RootStack = createStackNavigator(
     SearchSymptoms: SearchSymptoms,
     SymptomsQA,
     Results,
-    Doctors: DoctorsScreen
+    Doctors: DoctorsScreen,
+    Email: EmailScreen
   },
   {
     initialRouteName: 'Welcome',

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -41,6 +41,13 @@ export default function DoctorsScreen({ navigation }) {
         <ScrollView style={styles.doctorsContainer}>
           {nearbyPractices}
         </ScrollView>
+        <Button
+          block
+          style={styles.button}
+          onPress={() => navigation.navigate('Email')}
+        >
+          <Text style={styles.buttonText}>Email Report</Text>
+        </Button>
       </View>
     </View>
   );
@@ -70,5 +77,13 @@ const styles = StyleSheet.create({
   doctorName: {
     fontSize: 16,
     fontWeight: 'bold'
+  },
+  button: {
+    alignSelf: 'center',
+    marginTop: height * 0.02,
+    width: '75%'
+  },
+  buttonText: {
+    fontSize: 18
   }
 });

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -8,9 +8,9 @@ import { doctors } from '../../utils/mockDoctors/mockDoctors';
 const height = Dimensions.get('window').height;
 
 export default function DoctorsScreen({ navigation }) {
-  const nearbyPractices = doctors.map(doctor => {
+  const nearbyPractices = doctors.map((doctor, index) => {
     return (
-      <Card>
+      <Card key={index}>
         <CardItem>
           <Body>
             <Text style={styles.doctorName}>{doctor.practice.name}</Text>

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
-import { Button } from 'native-base';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Body, Card, CardItem } from 'native-base';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Entypo } from '@expo/vector-icons';
+import { Body, Button, Card, CardItem } from 'native-base';
+import { ScrollView } from 'react-native-gesture-handler';
 import { Header } from '../../components/Header';
 import { doctors } from '../../utils/mockDoctors/mockDoctors';
 
@@ -16,7 +13,7 @@ export default function DoctorsScreen({ navigation }) {
       <Card>
         <CardItem>
           <Body>
-            <Text>{doctor.practice.name}</Text>
+            <Text style={styles.doctorName}>{doctor.practice.name}</Text>
             <Text>Phone Number</Text>
           </Body>
         </CardItem>
@@ -36,11 +33,42 @@ export default function DoctorsScreen({ navigation }) {
   });
 
   return (
-    <View>
+    <View style={styles.container}>
       <Header />
-      {nearbyPractices}
+      <View style={styles.contentContainer}>
+        <Text style={styles.title}>Doctors and Specialists Near You:</Text>
+        {/* <Text style={styles.title}>Near You:</Text> */}
+        <ScrollView style={styles.doctorsContainer}>
+          {nearbyPractices}
+        </ScrollView>
+      </View>
     </View>
   );
 }
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingBottom: height * 0.075
+  },
+  contentContainer: {
+    alignItems: 'center',
+    flex: 1
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: height * 0.02,
+    marginTop: height * 0.02
+  },
+  doctorsContainer: {
+    marginLeft: height * 0.025,
+    marginRight: height * 0.025,
+    width: '95%'
+  },
+  doctorName: {
+    fontSize: 16,
+    fontWeight: 'bold'
+  }
+});

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { Button } from 'native-base';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Body, Card, CardItem } from 'native-base';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons';
+import { Header } from '../../components/Header';
+import { doctors } from '../../utils/mockDoctors/mockDoctors';
+
+const height = Dimensions.get('window').height;
+
+export default function DoctorsScreen({ navigation }) {
+  const nearbyPractices = doctors.map(doctor => {
+    return (
+      <Card>
+        <CardItem>
+          <Body>
+            <Text>{doctor.practice.name}</Text>
+            <Text>Phone Number</Text>
+          </Body>
+        </CardItem>
+        <CardItem>
+          <Body>
+            <Text>
+              {doctor.practice.street}. {doctor.practice.street2}
+            </Text>
+            <Text>
+              {doctor.practice.city}, {doctor.practice.state}{' '}
+              {doctor.practice.zip}
+            </Text>
+          </Body>
+        </CardItem>
+      </Card>
+    );
+  });
+
+  return (
+    <View>
+      <Header />
+      {nearbyPractices}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({});

--- a/screens/EmailScreen/EmailScreen.js
+++ b/screens/EmailScreen/EmailScreen.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Dimensions, Image, StyleSheet, View } from 'react-native';
+import { Button, Text } from 'native-base';
+import { Header } from '../../components/Header';
+
+const height = Dimensions.get('window').height;
+
+export default function EmailScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Header />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+
+  }
+})

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -19,14 +19,11 @@ export default function SymptomsQA({ navigation }) {
   const [conditionDetails, setConditionDetails] = useState({});
 
   useEffect(() => { getResults() }, []);
-  useEffect(() => { console.log('explain!', explanation) }, [explanation]);
-  useEffect(() => { console.log('deets', conditionDetails) }, [conditionDetails])
 
 
   const getResults = async () => {
     try {
       userInfo = specifyTargetCondition(userInfo, symptomFollowup);
-      console.log('symptom follow', symptomFollowup)
       let explanation = await getExplaination(userInfo);
       let conditionDetails = await getConditionById(symptomFollowup.conditions[0].id);
       setExplanation(explanation);

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -50,8 +50,6 @@ export default function SymptomsScreen({ navigation }) {
     });
   };
 
-  // useEffect(() => console.log('symptomIds', symptomIds));
-
   const displaySymptoms = searchResults.map(result => {
     let foundIndex = symptomIds.findIndex(symptom => symptom.id == result.id);
     return (

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -11,9 +11,7 @@ import {
   mockGroupMultiple,
   mockGroupSingle
 } from '../../utils/mockQuestions/mockQuestions';
-import {
-  sendInitialUserSymptoms
-} from '../../utils/apiCalls/apiCalls';
+import { sendInitialUserSymptoms } from '../../utils/apiCalls/apiCalls';
 
 const height = Dimensions.get('window').height;
 
@@ -24,42 +22,58 @@ export default function SymptomsQA({ navigation }) {
   const [question, setQuestion] = useState({});
   const [userInfo, setUserInfo] = useState(cleanedData);
 
-  useEffect(() => { getQA() }, [userInfo]);
-  useEffect(() => console.log('question', question), [question]);
-  useEffect(() => console.log('userInfo', userInfo), [userInfo]);
+  useEffect(() => {
+    getQA();
+  }, [userInfo]);
 
   const getQA = async () => {
     try {
-      let symptomFollowup = await
-        sendInitialUserSymptoms(userInfo);
-      console.log('symptom follow up?', symptomFollowup);
+      let symptomFollowup = await sendInitialUserSymptoms(userInfo);
       setQuestion(symptomFollowup);
-      symptomFollowup.should_stop ? navigation.navigate('Results', { userInfo, symptomFollowup }) : null;
+      symptomFollowup.should_stop
+        ? navigation.navigate('Results', { userInfo, symptomFollowup })
+        : null;
     } catch (error) {
       throw new Error(error);
     }
-  }
+  };
 
   const displayQuestion = () => {
     switch (question.question.type) {
       case 'single':
-        return <SingleQ style={styles.question} question={question} answerQuestion={answerQuestion} />
+        return (
+          <SingleQ
+            style={styles.question}
+            question={question}
+            answerQuestion={answerQuestion}
+          />
+        );
       case 'group_single':
-        return <GroupSingleQ style={styles.question} question={question} answerQuestion={answerQuestion} />
+        return (
+          <GroupSingleQ
+            style={styles.question}
+            question={question}
+            answerQuestion={answerQuestion}
+          />
+        );
       case 'group_multiple':
-        return <GroupSingleQ style={styles.question} question={question} answerQuestion={answerQuestion} />
+        return (
+          <GroupSingleQ
+            style={styles.question}
+            question={question}
+            answerQuestion={answerQuestion}
+          />
+        );
       default:
-        <></>
+        <></>;
     }
-  }
+  };
 
-  const answerQuestion = (answers) => {
-    console.log('oldUserInfo', userInfo)
+  const answerQuestion = answers => {
     const newUserInfo = { ...userInfo };
     newUserInfo.evidence.push(...answers);
-    console.log('newUserInfo', newUserInfo)
     setUserInfo(newUserInfo);
-  }
+  };
 
   return (
     <View style={styles.container}>
@@ -82,7 +96,7 @@ export default function SymptomsQA({ navigation }) {
             name='chevron-thin-down'
             size={36}
             color='white'
-          // onPress={() => }
+            // onPress={() => }
           />
         </View>
       </LinearGradient>

--- a/utils/helpers/helpers.js
+++ b/utils/helpers/helpers.js
@@ -32,6 +32,5 @@ export const specifyTargetCondition = (userInfo, symptomFollowup) => {
   userInfo.extras = {
     enable_triage_5: true
   };
-  console.log('UserInfo', userInfo)
   return userInfo;
 }

--- a/utils/mockDoctors/mockDoctors.js
+++ b/utils/mockDoctors/mockDoctors.js
@@ -1,0 +1,116 @@
+export const doctors = [
+  {
+    practice: {
+      location: 'co-denver',
+      lat: 39.73292,
+      lon: -104.94187,
+      city: 'Denver',
+      state: 'Colorado',
+      street: '1400 Jackson St',
+      street2: 'Ste J',
+      zip: '80206',
+      uid: 'ca3466def4a60da36654c49bf01ef94b',
+      name: 'ESther Langmack, MD',
+      accepts_new_patients: true,
+      insurance_uids: [
+        'multiplan-phcsppo',
+        'multiplan-multiplanppo',
+        'humana-humanahmopremierhix',
+        'humana-humanacohmoxhix',
+        'medicare-medicare',
+        'medicaid-medicaid',
+        'aetna-aetnamdbronzesilverandgoldhmo',
+        'premerabluecross-premeralifewiseconnect',
+        'gwhcigna-greatwestppo'
+      ]
+    },
+    profile: {
+      first_name: 'Esther',
+      middle_name: 'L',
+      last_name: 'Langmack',
+      title: 'MD',
+      school: 'University of California',
+      image_url:
+        'https://asset2.betterdoctor.com/assets/general_doctor_female.png',
+      gender: 'female',
+      bio:
+        'Dr. Esther Langmack, MD sees patients in Denver, Colorado and specializes in critical care medicine, internal medicine, and pulmonary disease.\n\nDr. Langmack graduated from University Of California and is licensed to treat patients in Colorado.\n\nIn addition to having active medical licenses, Dr. Langmack has passed an automated background check which looked at elements including medical license status and malpractice screening (no history found).'
+    }
+  },
+  {
+    practice: {
+      location: 'co-denver',
+      lat: 39.73292,
+      lon: -104.94187,
+      city: 'Denver',
+      state: 'Colorado',
+      street: '1400 Jackson St',
+      street2: 'Ste J',
+      zip: '80206',
+      uid: 'ca3466def4a60da36654c49bf01ef94b',
+      name: 'ESther Langmack, MD',
+      accepts_new_patients: true,
+      insurance_uids: [
+        'multiplan-phcsppo',
+        'multiplan-multiplanppo',
+        'humana-humanahmopremierhix',
+        'humana-humanacohmoxhix',
+        'medicare-medicare',
+        'medicaid-medicaid',
+        'aetna-aetnamdbronzesilverandgoldhmo',
+        'premerabluecross-premeralifewiseconnect',
+        'gwhcigna-greatwestppo'
+      ]
+    },
+    profile: {
+      first_name: 'Esther',
+      middle_name: 'L',
+      last_name: 'Langmack',
+      title: 'MD',
+      school: 'University of California',
+      image_url:
+        'https://asset2.betterdoctor.com/assets/general_doctor_female.png',
+      gender: 'female',
+      bio:
+        'Dr. Esther Langmack, MD sees patients in Denver, Colorado and specializes in critical care medicine, internal medicine, and pulmonary disease.\n\nDr. Langmack graduated from University Of California and is licensed to treat patients in Colorado.\n\nIn addition to having active medical licenses, Dr. Langmack has passed an automated background check which looked at elements including medical license status and malpractice screening (no history found).'
+    }
+  },
+  {
+    practice: {
+      location: 'co-denver',
+      lat: 39.73292,
+      lon: -104.94187,
+      city: 'Denver',
+      state: 'Colorado',
+      street: '1400 Jackson St',
+      street2: 'Ste J',
+      zip: '80206',
+      uid: 'ca3466def4a60da36654c49bf01ef94b',
+      name: 'ESther Langmack, MD',
+      accepts_new_patients: true,
+      insurance_uids: [
+        'multiplan-phcsppo',
+        'multiplan-multiplanppo',
+        'humana-humanahmopremierhix',
+        'humana-humanacohmoxhix',
+        'medicare-medicare',
+        'medicaid-medicaid',
+        'aetna-aetnamdbronzesilverandgoldhmo',
+        'premerabluecross-premeralifewiseconnect',
+        'gwhcigna-greatwestppo'
+      ]
+    },
+    profile: {
+      first_name: 'Esther',
+      middle_name: 'L',
+      last_name: 'Langmack',
+      title: 'MD',
+      school: 'University of California',
+      image_url:
+        'https://asset2.betterdoctor.com/assets/general_doctor_female.png',
+      gender: 'female',
+      bio:
+        'Dr. Esther Langmack, MD sees patients in Denver, Colorado and specializes in critical care medicine, internal medicine, and pulmonary disease.\n\nDr. Langmack graduated from University Of California and is licensed to treat patients in Colorado.\n\nIn addition to having active medical licenses, Dr. Langmack has passed an automated background check which looked at elements including medical license status and malpractice screening (no history found).'
+    }
+  }
+];


### PR DESCRIPTION
## What does this PR do?
This PR is very small and adds the simplest setup of the Doctors and Email screens. Email hardly has anything, but doctors has more structure to it (based on sample data from a file within the repo, not quite pulling from the backend yet, but should function similarly to the fetch now that we've spoken to Tylor)
### Where should the reviewer start?
In `DoctorsScreen.js` and `EmailScreen.js`
Like I said, there's no fetch happening to render the Doctor data, but it should be a quick implementation since nothing changed after speaking with Tylor. We'll have to add the phone number in now that it is available, and the email page will need some work. But I wanted something to do when I couldn't sleep, so here we are. Let me know if you see anything we should change/update!
#### How should this be manually tested?
Pull down, add in the navigation (after the components that we built today) and see if you can see the dummy data rendered!
#### Have tests been written for all functionality?
No.
#### Any background context you want to provide?
I mentioned most of it above.
#### What are the relevant tickets?
#12, #36, #37
#### Screenshots (if appropriate)
N/A
#### Additional Notes
Seriously, thank you for all your hard work today! We really flew through functionality!