### PR TITLE
Maintain selected symptoms on Symptoms screen

### DIFF
--- a/screens/BiologicalInformation/BiologicalInformation.js
+++ b/screens/BiologicalInformation/BiologicalInformation.js
@@ -68,8 +68,8 @@ export default function BiologicalInformation({ navigation }) {
               }}
             />
           ) : (
-            <Entypo name='chevron-thin-down' size={36} color='white' />
-          )}
+              <Entypo name='chevron-thin-down' size={36} color='white' />
+            )}
         </View>
       </LinearGradient>
     </View>
@@ -87,8 +87,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'space-between',
-    marginBottom: height * 0.04,
-    marginTop: height * 0.09
+    marginBottom: height * 0.06,
+    marginTop: height * 0.06,
   },
   question: {
     color: '#FFFFFF',

--- a/screens/LocationScreen/LocationScreen.js
+++ b/screens/LocationScreen/LocationScreen.js
@@ -78,8 +78,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'space-between',
-    marginTop: height * 0.075,
-    marginBottom: height * 0.05
+    marginBottom: height * 0.06,
+    marginTop: height * 0.06,
   },
   container: {
     flex: 1

--- a/screens/RiskFactors/RiskFactors.js
+++ b/screens/RiskFactors/RiskFactors.js
@@ -122,8 +122,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'space-evenly',
-    marginBottom: height * 0.015,
-    marginTop: height * 0.025
+    marginBottom: height * 0.06,
+    marginTop: height * 0.06
   },
   gradientBackground: {
     flex: 1

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -17,7 +17,7 @@ export default function SymptomsScreen({ navigation }) {
     sex,
     stateAbbreviation
   } = navigation.state.params;
-  const [symptomIds, setSymptomIds] = useState([]);
+  const [symptoms, setSymptoms] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
 
   const searchSymptoms = async text => {
@@ -29,23 +29,40 @@ export default function SymptomsScreen({ navigation }) {
     }
   };
 
-  const findSymptom = id => {
-    let existingSymptom = symptomIds.find(symptom => symptom.id == id);
-    existingSymptom ? removeSymptom(id) : addSymptom(id);
+  const displaySelectedSymptoms =
+    symptoms.map((symptom, index) => {
+      return (
+        <CardItem key={index} style={styles.selectedSymptom}>
+          <Text>{symptom.common_name}</Text>
+          <AntDesign
+            name='closecircle'
+            id={symptom.id}
+            size={26}
+          // onPress={() => {
+          // }}
+          />
+        </CardItem>)
+    })
+
+
+
+  const findSymptom = result => {
+    let existingSymptom = symptoms.find(symptom => symptom.id == result.id);
+    existingSymptom ? removeSymptom(result) : addSymptom(result);
   };
 
-  const addSymptom = id => {
-    let found = searchResults.find(symptom => symptom.id == id);
-    setSymptomIds([...symptomIds, { id: found.id, present: true }]);
+  const addSymptom = result => {
+    let found = searchResults.find(symptom => symptom.id == result.id);
+    setSymptoms([...symptoms, { ...result, present: true }]);
   };
 
-  const removeSymptom = id => {
-    let filteredSymptoms = symptomIds.filter(symptom => symptom.id !== id);
-    setSymptomIds(filteredSymptoms);
+  const removeSymptom = result => {
+    let filteredSymptoms = symptoms.filter(symptom => symptom.id !== result.id);
+    setSymptoms(filteredSymptoms);
   };
 
   const sendInitialSymptoms = () => {
-    const userInfo = { age, presentFactors, symptomIds, sex };
+    const userInfo = { age, presentFactors, symptoms, sex };
     let cleanedData = cleanInitialUserReport(userInfo);
     navigation.navigate('SymptomsQA', {
       cleanedData,
@@ -54,19 +71,19 @@ export default function SymptomsScreen({ navigation }) {
     });
   };
 
-  const displaySymptoms = searchResults.map(result => {
-    let foundIndex = symptomIds.findIndex(symptom => symptom.id == result.id);
+  const displaySymptoms = searchResults.map((result, index) => {
+    let found = symptoms.find(symptom => symptom.id == result.id);
     return (
-      <View style={styles.checkboxes}>
+      <View key={index} style={styles.checkboxes}>
         <Text style={styles.symptomText}>{result.common_name}?</Text>
         <AntDesign
-          name='pluscircleo'
+          name={found ? 'checkcircle' : 'pluscircleo'}
           id={result.id}
           style={styles.add}
           size={26}
           color='black'
           onPress={() => {
-            findSymptom(result.id);
+            findSymptom(result);
           }}
         />
       </View>
@@ -106,6 +123,11 @@ export default function SymptomsScreen({ navigation }) {
             <Text style={styles.hint}>
               Select all that apply (at least 3):
             </Text>
+            <ScrollView style={styles.selected}>
+              <Card style={styles.selectedContainer}>
+                {displaySelectedSymptoms}
+              </Card>
+            </ScrollView>
             <ScrollView style={styles.searchResults}>
               {displaySymptoms}
             </ScrollView>
@@ -162,6 +184,9 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     paddingTop: height * 0.025
   },
+  selected: {
+    flex: 1
+  },
   searchResultsContainer: {
     alignItems: 'center',
     flex: 1,
@@ -169,6 +194,22 @@ const styles = StyleSheet.create({
     justifyContent: 'space-evenly',
     marginBottom: height * 0.016,
     width: '100%'
+  },
+  selectedContainer: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(256, 256, 256, 0)',
+    flex: 1,
+    flexGrow: 1,
+    width: '100%',
+  },
+  selectedSymptom: {
+    backgroundColor: 'rgba(256, 256, 256, 0.9)',
+    borderRadius: 50,
+    height: 80,
+    flexDirection: 'row',
+    justifyContent: "space-between",
+    marginTop: 10,
+    padding: 10,
   },
   searchResults: {
     width: 0,
@@ -181,9 +222,6 @@ const styles = StyleSheet.create({
   symptomText: {
     fontSize: 18,
     width: '70%'
-  },
-  add: {
-
   },
   checkboxes: {
     alignItems: 'center',

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -33,13 +33,15 @@ export default function SymptomsScreen({ navigation }) {
     symptoms.map((symptom, index) => {
       return (
         <CardItem key={index} style={styles.selectedSymptom}>
-          <Text>{symptom.common_name}</Text>
+          <Text style={{ fontSize: 14 }}>{symptom.common_name}</Text>
           <AntDesign
             name='closecircle'
+            style={styles.delete}
             id={symptom.id}
             size={26}
-          // onPress={() => {
-          // }}
+            onPress={() => {
+              findSymptom(symptom)
+            }}
           />
         </CardItem>)
     })
@@ -117,21 +119,20 @@ export default function SymptomsScreen({ navigation }) {
               size={36}
               style={styles.searchIcon}
             />
-
           </Item>
-          <View style={styles.searchResultsContainer}>
-            <Text style={styles.hint}>
-              Select all that apply (at least 3):
+          <Text style={styles.hint}>
+            Select all that apply (at least 3):
             </Text>
-            <ScrollView style={styles.selected}>
+          <ScrollView style={styles.scroll}>
+            <View style={styles.searchResultsContainer}>
               <Card style={styles.selectedContainer}>
                 {displaySelectedSymptoms}
               </Card>
-            </ScrollView>
-            <ScrollView style={styles.searchResults}>
+            </View>
+            <View style={styles.searchResults}>
               {displaySymptoms}
-            </ScrollView>
-          </View>
+            </View>
+          </ScrollView>
           <Entypo
             name='chevron-thin-down'
             size={36}
@@ -169,6 +170,10 @@ const styles = StyleSheet.create({
     marginTop: height * 0.06,
     width: '100%'
   },
+  scroll: {
+    marginTop: height * 0.01,
+    width: '100%'
+  },
   input: {
     color: 'white',
     fontSize: 24,
@@ -184,37 +189,32 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     paddingTop: height * 0.025
   },
-  selected: {
-    flex: 1
-  },
   searchResultsContainer: {
-    alignItems: 'center',
-    flex: 1,
-    height: height * 0.65,
-    justifyContent: 'space-evenly',
-    marginBottom: height * 0.016,
+    marginLeft: '5%',
     width: '100%'
   },
   selectedContainer: {
-    alignItems: 'center',
+    borderColor: 'rgba(256, 256, 256, 0)',
     backgroundColor: 'rgba(256, 256, 256, 0)',
-    flex: 1,
-    flexGrow: 1,
-    width: '100%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    width: '80%',
   },
   selectedSymptom: {
     backgroundColor: 'rgba(256, 256, 256, 0.9)',
     borderRadius: 50,
-    height: 80,
+    height: height * 0.06,
     flexDirection: 'row',
     justifyContent: "space-between",
+    marginLeft: 5,
     marginTop: 10,
     padding: 10,
   },
   searchResults: {
+    alignSelf: 'center',
     width: 0,
     flexGrow: 1,
-    flex: 1,
+    flex: 0.5,
     marginTop: height * 0.02,
     padding: 0,
     width: '90%'
@@ -232,5 +232,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: "space-between",
     padding: 10
+  },
+  delete: {
+    marginLeft: 10
   }
 });

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { Body, Card, CardItem, Input, Item } from 'native-base';
-import { CheckBox } from 'react-native-elements';
-import { Entypo, Ionicons } from '@expo/vector-icons';
+import { Entypo, AntDesign, Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollView } from 'react-native-gesture-handler';
 import { searchAllSymptoms } from '../../utils/apiCalls/apiCalls';
@@ -26,7 +25,7 @@ export default function SymptomsScreen({ navigation }) {
       const searchResults = await searchAllSymptoms(text);
       setSearchResults(searchResults.data);
     } else {
-      null;
+      setSearchResults([]);
     }
   };
 
@@ -58,24 +57,19 @@ export default function SymptomsScreen({ navigation }) {
   const displaySymptoms = searchResults.map(result => {
     let foundIndex = symptomIds.findIndex(symptom => symptom.id == result.id);
     return (
-      <Card key={result.id} style={styles.searchResultCard}>
-        <CardItem>
-          <Body>
-            <Text style={styles.symptomText}>{result.common_name}?</Text>
-            <View style={styles.checkboxes}>
-              <CheckBox
-                center
-                id={result.id}
-                title={<Text>Add Symptom</Text>}
-                // checked={}
-                onPress={() => {
-                  findSymptom(result.id);
-                }}
-              ></CheckBox>
-            </View>
-          </Body>
-        </CardItem>
-      </Card>
+      <View style={styles.checkboxes}>
+        <Text style={styles.symptomText}>{result.common_name}?</Text>
+        <AntDesign
+          name='pluscircleo'
+          id={result.id}
+          style={styles.add}
+          size={26}
+          color='black'
+          onPress={() => {
+            findSymptom(result.id);
+          }}
+        />
+      </View>
     );
   });
 
@@ -92,10 +86,11 @@ export default function SymptomsScreen({ navigation }) {
             color='white'
             onPress={() => navigation.navigate('RiskFactors')}
           />
-          <Text style={styles.title}>Symptoms:</Text>
+          <Text style={styles.title}>Symptoms</Text>
           <Item style={styles.searchBox}>
             <Input
               placeholder='Search all symptoms'
+              placeholderTextColor="#f8f8f8"
               style={styles.input}
               onChangeText={text => searchSymptoms(text)}
             />
@@ -105,9 +100,10 @@ export default function SymptomsScreen({ navigation }) {
               size={36}
               style={styles.searchIcon}
             />
+
           </Item>
           <View style={styles.searchResultsContainer}>
-            <Text style={styles.input}>
+            <Text style={styles.hint}>
               Select all that apply (at least 3):
             </Text>
             <ScrollView style={styles.searchResults}>
@@ -135,6 +131,8 @@ const styles = StyleSheet.create({
     color: 'white'
   },
   searchBox: {
+    marginBottom: height * 0.01,
+    marginTop: height * 0.01,
     width: '75%'
   },
   container: {
@@ -145,14 +143,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center',
-    marginBottom: height * 0.05,
-    marginTop: height * 0.05,
+    marginBottom: height * 0.06,
+    marginTop: height * 0.06,
     width: '100%'
   },
   input: {
     color: 'white',
     fontSize: 24,
     fontWeight: 'bold'
+  },
+  hint: {
+    color: 'white',
+    fontSize: 20,
   },
   title: {
     color: 'white',
@@ -169,22 +171,28 @@ const styles = StyleSheet.create({
     width: '100%'
   },
   searchResults: {
+    width: 0,
+    flexGrow: 1,
     flex: 1,
+    marginTop: height * 0.02,
     padding: 0,
-    width: '80%'
-  },
-  searchResultCard: {
-    marginBottom: height * 0.01,
-    marginTop: height * 0.01,
-    width: '100%'
+    width: '90%'
   },
   symptomText: {
-    alignSelf: 'flex-start',
-    fontSize: 16,
-    padding: 0
+    fontSize: 18,
+    width: '70%'
+  },
+  add: {
+
   },
   checkboxes: {
-    flex: 1,
-    flexDirection: 'row'
+    alignItems: 'center',
+    backgroundColor: 'rgba(256, 256, 256, 0.7)',
+    borderBottomWidth: 2,
+    borderColor: 'grey',
+    height: 80,
+    flexDirection: 'row',
+    justifyContent: "space-between",
+    padding: 10
   }
 });

--- a/screens/SelectAge/SelectAge.js
+++ b/screens/SelectAge/SelectAge.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Item, Input } from 'native-base';
 import { Entypo, MaterialIcons } from '@expo/vector-icons';
+
+const height = Dimensions.get('window').height;
 
 export default function SelectAge({ navigation }) {
   const sex = navigation.state.params.sex;
@@ -49,8 +51,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'space-between',
-    marginBottom: 20,
-    marginTop: 20
+    marginBottom: height * 0.06,
+    marginTop: height * 0.06,
   },
   container: {
     flex: 1

--- a/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
+++ b/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, Fragment } from 'react';
 import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
 import { Button } from 'native-base';
 import { CheckBox } from 'react-native-elements';
@@ -15,95 +15,98 @@ export default function TermsAndConditionsScreen({ navigation }) {
   });
 
   return (
-    <ScrollView style={styles.container}>
+    <Fragment>
       <Header />
-      <View style={styles.contentContainer}>
-        <AntDesign
-          name='close'
-          size={24}
-          color='black'
-          style={styles.close}
-          onPress={() => navigation.navigate('Welcome')}
-        />
-        <Image
-          source={require('../../assets/images/terms-and-conditions.png')}
-          style={styles.icon}
-        />
-        <Text style={styles.heading}>Terms and Conditions</Text>
-        <View style={styles.scrollContainer}>
-          <ScrollView style={styles.scrollText}>
-            <Text style={styles.legal}>
-              “Version” means the original licensor to copy, sublicense,
-              distribute or transfer NetHack is modified by someone else and
-              passed on, we want its recipients to know that what they have
-              requested that this License or the Derived Program under this
-              License, or (at your option) any later version published by the
-              Free Software Foundation; either version 2 of this License,
-              provided that you include complete instructions on how and where
-              you have knowledge of patent licenses granted hereunder, each
-              Recipient hereby assumes sole responsibility to serve as the
-              Derived Work. If you initiate litigation by asserting a patent
-              infringement claim against Respondent alleging that the
-              Modification is derived, directly or indirectly, from the
-              conditions listed in manifest.txt. Effect of New York and the date
-              of initial External Deployment, whichever is longer. You should
-              also get your employer (if you work as “Original Code” means the
-              original Licensed Product. However, you may do only in or as part
-              of Licensed Product is available under this Agreement shall
-              terminate on the Internet using the software, or if you distribute
-              any Modifications you distribute any Modifications that alter or
-              otherwise using Python 1.6, beta 1, is made available by Apple
-              under this Agreement is published, Contributor may elect to
-              distribute this Package shall not apply to your programs, too.
-              When we speak of free software Package may be distributed and/or
-              modified under the Original Code, and if a third party against the
-              Indemnified Contributor may elect to distribute your Derivative
-              Works from it. Works” is defined in Article 1 below) constitutes
-              the entire Package. You may do so if it has sufficient copyright
-              rights in the Program: Copyright (C) year name of the Initial
-              Developer and every Contributor for any version ever published by
-              the Initial Developer and every part regardless of who wrote it.
-              Thus, it is not the Current Maintainer (and the Copyright Holder.
-              The resulting Package will still be considered the Standard
-              Version. License) and (b) the object code compiled from such
-              Recipient under this Agreement, whether expressly, by implication,
-              estoppel or otherwise.
-              {/* TODO: Put real lawyer lingo here */}
-            </Text>
-          </ScrollView>
-        </View>
-        <View>
-          <CheckBox
-            center
-            title={
-              <Text style={styles.agreement}>
-                I read and accept the Terms of Service and Privacy Policy
-              </Text>
-            }
-            checked={state.checked}
-            onPress={() =>
-              setState({
-                checked: !state.checked,
-                isButtonEnabled: !state.isButtonEnabled
-              })
-            }
+      <ScrollView style={styles.container}>
+        <View style={styles.contentContainer}>
+          <AntDesign
+            name='close'
+            size={24}
+            color='black'
+            style={styles.close}
+            onPress={() => navigation.navigate('Welcome')}
           />
+          <Image
+            source={require('../../assets/images/terms-and-conditions.png')}
+            style={styles.icon}
+          />
+          <Text style={styles.heading}>Terms and Conditions</Text>
+          <View style={styles.scrollContainer}>
+            <ScrollView style={styles.scrollText}>
+              <Text style={styles.legal}>
+                “Version” means the original licensor to copy, sublicense,
+                distribute or transfer NetHack is modified by someone else and
+                passed on, we want its recipients to know that what they have
+                requested that this License or the Derived Program under this
+                License, or (at your option) any later version published by the
+                Free Software Foundation; either version 2 of this License,
+                provided that you include complete instructions on how and where
+                you have knowledge of patent licenses granted hereunder, each
+                Recipient hereby assumes sole responsibility to serve as the
+                Derived Work. If you initiate litigation by asserting a patent
+                infringement claim against Respondent alleging that the
+                Modification is derived, directly or indirectly, from the
+                conditions listed in manifest.txt. Effect of New York and the date
+                of initial External Deployment, whichever is longer. You should
+                also get your employer (if you work as “Original Code” means the
+                original Licensed Product. However, you may do only in or as part
+                of Licensed Product is available under this Agreement shall
+                terminate on the Internet using the software, or if you distribute
+                any Modifications you distribute any Modifications that alter or
+                otherwise using Python 1.6, beta 1, is made available by Apple
+                under this Agreement is published, Contributor may elect to
+                distribute this Package shall not apply to your programs, too.
+                When we speak of free software Package may be distributed and/or
+                modified under the Original Code, and if a third party against the
+                Indemnified Contributor may elect to distribute your Derivative
+                Works from it. Works” is defined in Article 1 below) constitutes
+                the entire Package. You may do so if it has sufficient copyright
+                rights in the Program: Copyright (C) year name of the Initial
+                Developer and every Contributor for any version ever published by
+                the Initial Developer and every part regardless of who wrote it.
+                Thus, it is not the Current Maintainer (and the Copyright Holder.
+                The resulting Package will still be considered the Standard
+                Version. License) and (b) the object code compiled from such
+                Recipient under this Agreement, whether expressly, by implication,
+                estoppel or otherwise.
+              {/* TODO: Put real lawyer lingo here */}
+              </Text>
+            </ScrollView>
+          </View>
+          <View>
+            <CheckBox
+              center
+              title={
+                <Text style={styles.agreement}>
+                  I read and accept the Terms of Service and Privacy Policy
+              </Text>
+              }
+              checked={state.checked}
+              onPress={() =>
+                setState({
+                  checked: !state.checked,
+                  isButtonEnabled: !state.isButtonEnabled
+                })
+              }
+            />
+          </View>
+          {state.isButtonEnabled ? (
+            <Button
+              block
+              style={styles.button}
+              onPress={() => navigation.navigate('BiologicalInformation')}
+            >
+              <Text>CONTINUE</Text>
+            </Button>
+          ) : (
+              <Button disabled block style={styles.button}>
+                <Text>CONTINUE</Text>
+              </Button>
+            )}
         </View>
-        {state.isButtonEnabled ? (
-          <Button
-            block
-            style={styles.button}
-            onPress={() => navigation.navigate('BiologicalInformation')}
-          >
-            <Text>CONTINUE</Text>
-          </Button>
-        ) : (
-          <Button disabled block style={styles.button}>
-            <Text>CONTINUE</Text>
-          </Button>
-        )}
-      </View>
-    </ScrollView>
+      </ScrollView>
+    </Fragment>
+
   );
 }
 

--- a/utils/helpers/helpers.js
+++ b/utils/helpers/helpers.js
@@ -1,7 +1,7 @@
 export const cleanInitialUserReport = report => {
-  const { age, presentFactors, sex, symptomIds } = report;
+  const { age, presentFactors, sex, symptoms } = report;
   let riskFactors = cleanFactorArrays(presentFactors);
-  let initialSymptoms = cleanFactorArrays(symptomIds);
+  let initialSymptoms = cleanSymptomArrays(symptoms);
   let initialSymptom = setInitialSymptom(initialSymptoms[0]);
   initialSymptoms[0] = initialSymptom;
   const cleanedFormat = {
@@ -15,6 +15,17 @@ export const cleanInitialUserReport = report => {
 export const cleanFactorArrays = factors => {
   let filtered = factors.filter(factor => factor.present === true);
   let ids = filtered.map(factor => factor.id);
+  return ids.map(id => {
+    return {
+      id: id,
+      choice_id: 'present'
+    };
+  });
+};
+
+export const cleanSymptomArrays = symptoms => {
+  let filtered = symptoms.filter(symptom => symptom.present === true);
+  let ids = filtered.map(symptom => symptom.id);
   return ids.map(id => {
     return {
       id: id,


### PR DESCRIPTION
## What does this PR do?

- [x] Adds visual cues for adding symptoms
- [x] Styles Symptom screen
- [x] Maintains stored symptoms
- [x] Allows user to delete selected symptoms if they accidentally click symptom

### Where should the reviewer start?

screens/SearchSymptoms/SearchSymptoms.js

#### How should this be manually tested?

`expo start` and add some symptoms and delete some symptoms

#### Have tests been written for all functionality?

No

#### What are the relevant tickets?

closes #32 

#### Screenshots (if appropriate)

<img width="397" alt="Screen Shot 2020-01-06 at 2 18 23 PM" src="https://user-images.githubusercontent.com/25589695/71849513-76cfae00-308f-11ea-9042-140f01ef3075.png">

