### PR TITLE
Clean conditional navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,5 @@
-import { AppLoading } from 'expo';
-import { Asset } from 'expo-asset';
 import * as Font from 'expo-font';
-import React, { useState } from 'react';
-import { Platform, StatusBar, StyleSheet, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
 import { AppContainer } from './navigation/AppContainer';
 
 export default class App extends React.Component {
@@ -12,60 +8,4 @@ export default class App extends React.Component {
   }
 }
 
-// export default function App(props) {
-//   const [isLoadingComplete, setLoadingComplete] = useState(false);
 
-//   if (!isLoadingComplete && !props.skipLoadingScreen) {
-//     return (
-//       <AppLoading
-//         startAsync={loadResourcesAsync}
-//         onError={handleLoadingError}
-//         onFinish={() => handleFinishLoading(setLoadingComplete)}
-//       />
-//     );
-//   } else {
-//     return (
-//     <View style={styles.container}>
-//     {/* {Platform.OS === 'ios' && <StatusBar barStyle='default' />} */ }
-//     {/* <WelcomeScreen /> */ }
-//     {/* <TermsOfConditionsScreen /> */ }
-//     {/* <BiologicalInformation /> */ }
-//     {/* <LocationScreen /> */ }
-//     {/* <SelectAge /> */ }
-//     </View>
-//     );
-//   }
-// }
-
-async function loadResourcesAsync() {
-  await Promise.all([
-    Asset.loadAsync([
-      require('./assets/images/robot-dev.png'),
-      require('./assets/images/robot-prod.png')
-    ]),
-    Font.loadAsync({
-      // This is the font that we are using for our tab bar
-      ...Ionicons.font,
-      // We include SpaceMono because we use it in HomeScreen.js. Feel free to
-      // remove this if you are not using it in your app
-      'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf')
-    })
-  ]);
-}
-
-function handleLoadingError(error) {
-  // In this case, you might want to report the error to your error reporting
-  // service, for example Sentry
-  console.warn(error);
-}
-
-function handleFinishLoading(setLoadingComplete) {
-  setLoadingComplete(true);
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff'
-  }
-});

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -54,9 +54,14 @@ export default function GroupSingleQ({ question, answerQuestion }) {
       <Body>
         <Text style={styles.questionText}>{question.question.text}</Text>
         {questions}
-        <Button onPress={() => handleSubmit()}>
-          <Text>Submit</Text>
-        </Button>
+        {console.log(checkWho.length === question.question.items.length)}
+        {checkWho.length === question.question.items.length ?
+          (<Button block onPress={() => handleSubmit()}>
+            <Text>Submit</Text>
+          </Button>) :
+          (<Button disabled block>
+            <Text>Submit</Text>
+          </Button>)}
       </Body>
     </Card>
   );

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -39,9 +39,13 @@ export default function SingleQ({ question, answerQuestion }) {
         <Body>
           <Text style={styles.questionText}>{question.question.text}</Text>
           <View style={styles.checkboxes}>{choices}</View>
-          <Button block onPress={() => handleSubmit()}>
-            <Text>Submit</Text>
-          </Button>
+          {checkWho.length ?
+            (<Button block onPress={() => handleSubmit()}>
+              <Text>Submit</Text>
+            </Button>) :
+            (<Button disabled block>
+              <Text>Submit</Text>
+            </Button>)}
         </Body>
       </CardItem>
     </Card>

--- a/screens/BiologicalInformation/BiologicalInformation.js
+++ b/screens/BiologicalInformation/BiologicalInformation.js
@@ -21,7 +21,7 @@ export default function BiologicalInformation({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('TermsAndConditions')}
+            onPress={() => navigation.goBack()}
           />
           <Text style={styles.question}>What is your biological sex?</Text>
           <View style={styles.buttonContainer}>
@@ -58,18 +58,15 @@ export default function BiologicalInformation({ navigation }) {
               <Text style={styles.biologicalInformationButtonText}>Male</Text>
             </Button>
           </View>
-          {sex ? (
+          {sex !== '' &&
             <Entypo
               name='chevron-thin-down'
               size={36}
               color='white'
               onPress={() => {
-                sex !== '' ? navigation.navigate('SelectAge', { sex }) : <></>;
+                navigation.push('SelectAge', { sex })
               }}
-            />
-          ) : (
-              <Entypo name='chevron-thin-down' size={36} color='white' />
-            )}
+            />}
         </View>
       </LinearGradient>
     </View>

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -99,7 +99,6 @@ export default function DoctorsScreen({ navigation }) {
               {doctor.practice.city}, {doctor.practice.state}{' '}
               {doctor.practice.zip}
             </Text>
-            {/* <Text>{distance}</Text> */}
           </Body>
         </CardItem>
       </Card>
@@ -108,11 +107,15 @@ export default function DoctorsScreen({ navigation }) {
 
   const handleChange = async itemValue => {
     setCurrentProvider(itemValue);
-    const doctors = await getDoctorsForProviderByLocation(
-      stateAbbreviation,
-      currentProvider
-    );
-    setDoctors(doctors);
+    if (itemValue !== 'none') {
+      const doctors = await getDoctorsForProviderByLocation(
+        stateAbbreviation,
+        currentProvider
+      );
+      setDoctors(doctors);
+    } else {
+      getDoctorsForLocation();
+    }
   };
 
   return (
@@ -141,7 +144,7 @@ export default function DoctorsScreen({ navigation }) {
           block
           style={styles.button}
           onPress={() =>
-            navigation.navigate('Email', {
+            navigation.push('Email', {
               location,
               stateAbbreviation,
               report

--- a/screens/EmailScreen/EmailScreen.js
+++ b/screens/EmailScreen/EmailScreen.js
@@ -64,61 +64,62 @@ export default function EmailScreen({ navigation }) {
             </Button>
           </Fragment>
         ) : (
-          <Fragment>
-            <Item style={styles.input}>
-              <Input
-                placeholder='Enter your email address'
-                style={styles.input}
-                onChangeText={text => validateEmail(text)}
-              />
-            </Item>
-            <View style={styles.buttonContainer}>
-              {enabled ? (
-                <Button
-                  rounded
-                  style={styles.button}
-                  onPress={() => sendEmail()}
-                >
-                  <Text style={styles.buttonText}>Send Report</Text>
-                  <Ionicons
-                    name='ios-send'
-                    style={styles.icon}
-                    size={26}
-                    color='white'
-                  />
-                </Button>
-              ) : (
-                <Button
-                  disabled
-                  rounded
-                  style={styles.button}
-                  onPress={() => sendEmail()}
-                >
-                  <Text style={styles.buttonText}>Send Report</Text>
-                  <Ionicons
-                    name='ios-send'
-                    style={styles.icon}
-                    size={26}
-                    color='white'
-                  />
-                </Button>
-              )}
-              <Button
-                rounded
-                style={styles.button}
-                onPress={() => navigation.push('Welcome')}
-              >
-                <Text style={styles.buttonText}>New Checkup</Text>
-                <MaterialCommunityIcons
-                  name='stethoscope'
-                  style={styles.icon}
-                  size={26}
-                  color='white'
+            <Fragment>
+              <Item style={styles.input}>
+                <Input
+                  placeholder='Enter your email address'
+                  style={styles.input}
+                  autoCapitalize='none'
+                  onChangeText={text => validateEmail(text)}
                 />
-              </Button>
-            </View>
-          </Fragment>
-        )}
+              </Item>
+              <View style={styles.buttonContainer}>
+                {enabled ? (
+                  <Button
+                    rounded
+                    style={styles.button}
+                    onPress={() => sendEmail()}
+                  >
+                    <Text style={styles.buttonText}>Send Report</Text>
+                    <Ionicons
+                      name='ios-send'
+                      style={styles.icon}
+                      size={26}
+                      color='white'
+                    />
+                  </Button>
+                ) : (
+                    <Button
+                      disabled
+                      rounded
+                      style={styles.button}
+                      onPress={() => sendEmail()}
+                    >
+                      <Text style={styles.buttonText}>Send Report</Text>
+                      <Ionicons
+                        name='ios-send'
+                        style={styles.icon}
+                        size={26}
+                        color='white'
+                      />
+                    </Button>
+                  )}
+                <Button
+                  rounded
+                  style={styles.button}
+                  onPress={() => navigation.push('Welcome')}
+                >
+                  <Text style={styles.buttonText}>New Checkup</Text>
+                  <MaterialCommunityIcons
+                    name='stethoscope'
+                    style={styles.icon}
+                    size={26}
+                    color='white'
+                  />
+                </Button>
+              </View>
+            </Fragment>
+          )}
       </View>
     </Fragment>
   );

--- a/screens/LocationScreen/LocationScreen.js
+++ b/screens/LocationScreen/LocationScreen.js
@@ -42,7 +42,7 @@ export default function LocationScreen({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('SelectAge')}
+            onPress={() => navigation.goBack()}
           />
           <Text style={styles.title}>Location</Text>
           <Picker
@@ -59,7 +59,7 @@ export default function LocationScreen({ navigation }) {
             size={36}
             color='white'
             onPress={() =>
-              navigation.navigate('RiskFactors', {
+              navigation.push('RiskFactors', {
                 sex,
                 age,
                 location,

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -87,7 +87,7 @@ export default function SymptomsQA({ navigation }) {
       </ScrollView>
       <Button
         onPress={() =>
-          navigation.navigate('Doctors', {
+          navigation.push('Doctors', {
             location,
             stateAbbreviation,
             userInfo,

--- a/screens/RiskFactors/RiskFactors.js
+++ b/screens/RiskFactors/RiskFactors.js
@@ -88,7 +88,7 @@ export default function RiskFactors({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('Location')}
+            onPress={() => navigation.goBack()}
           />
           <View style={styles.contentContainer}>
             <Text style={styles.header}>Common Risk Factors:</Text>
@@ -99,7 +99,7 @@ export default function RiskFactors({ navigation }) {
             size={36}
             color='white'
             onPress={() =>
-              navigation.navigate('SearchSymptoms', {
+              navigation.push('SearchSymptoms', {
                 age,
                 location,
                 sex,

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -66,7 +66,7 @@ export default function SymptomsScreen({ navigation }) {
   const sendInitialSymptoms = () => {
     const userInfo = { age, presentFactors, symptoms, sex };
     let cleanedData = cleanInitialUserReport(userInfo);
-    navigation.navigate('SymptomsQA', {
+    navigation.push('SymptomsQA', {
       cleanedData,
       location,
       stateAbbreviation
@@ -103,7 +103,7 @@ export default function SymptomsScreen({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('RiskFactors')}
+            onPress={() => navigation.goBack()}
           />
           <Text style={styles.title}>Symptoms</Text>
           <Item style={styles.searchBox}>
@@ -133,12 +133,12 @@ export default function SymptomsScreen({ navigation }) {
               {displaySymptoms}
             </View>
           </ScrollView>
-          <Entypo
+          {symptoms.length >= 3 && <Entypo
             name='chevron-thin-down'
             size={36}
             color='white'
             onPress={() => sendInitialSymptoms()}
-          />
+          />}
         </View>
       </LinearGradient>
     </View>

--- a/screens/SelectAge/SelectAge.js
+++ b/screens/SelectAge/SelectAge.js
@@ -21,7 +21,7 @@ export default function SelectAge({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('BiologicalInformation')}
+            onPress={() => navigation.goBack()}
           />
           <View style={styles.childContainer}>
             <Text style={styles.title}>Age</Text>
@@ -34,12 +34,12 @@ export default function SelectAge({ navigation }) {
               />
             </Item>
           </View>
-          <Entypo
+          {age !== '' && (<Entypo
             name='chevron-thin-down'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('Location', { sex, age })}
-          />
+            onPress={() => navigation.push('Location', { sex, age })}
+          />)}
         </View>
       </LinearGradient>
     </View>

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -10,8 +10,6 @@ import { sendInitialUserSymptoms } from '../../utils/apiCalls/apiCalls';
 const height = Dimensions.get('window').height;
 
 export default function SymptomsQA({ navigation }) {
-  // const { age, location, presentFactors, sex, symptomFollowup } = navigation.state.params;
-  // const [currentQuestion, setCurrentQuestion] = useState({})
   const { cleanedData, location, stateAbbreviation } = navigation.state.params;
   const [question, setQuestion] = useState({});
   const [userInfo, setUserInfo] = useState(cleanedData);
@@ -25,12 +23,12 @@ export default function SymptomsQA({ navigation }) {
       let symptomFollowup = await sendInitialUserSymptoms(userInfo);
       setQuestion(symptomFollowup);
       symptomFollowup.should_stop
-        ? navigation.navigate('Results', {
-            userInfo,
-            symptomFollowup,
-            location,
-            stateAbbreviation
-          })
+        ? navigation.push('Results', {
+          userInfo,
+          symptomFollowup,
+          location,
+          stateAbbreviation
+        })
         : null;
     } catch (error) {
       throw new Error(error);
@@ -85,18 +83,12 @@ export default function SymptomsQA({ navigation }) {
             name='chevron-thin-up'
             size={36}
             color='white'
-            onPress={() => navigation.navigate('SearchSymptoms')}
+            onPress={() => navigation.goBack()}
           />
           <Text style={styles.symptomText}>Regarding your symptoms:</Text>
           <ScrollView style={styles.card}>
             {question.question && displayQuestion()}
           </ScrollView>
-          <Entypo
-            name='chevron-thin-down'
-            size={36}
-            color='white'
-            // onPress={() => }
-          />
         </View>
       </LinearGradient>
     </View>

--- a/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
+++ b/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
@@ -9,7 +9,7 @@ import { AntDesign } from '@expo/vector-icons';
 const height = Dimensions.get('window').height;
 
 export default function TermsAndConditionsScreen({ navigation }) {
-  const [state, setState] = useState({
+  const [isChecked, setIsChecked] = useState({
     checked: false,
     isButtonEnabled: false
   });
@@ -24,7 +24,7 @@ export default function TermsAndConditionsScreen({ navigation }) {
             size={24}
             color='black'
             style={styles.close}
-            onPress={() => navigation.navigate('Welcome')}
+            onPress={() => navigation.push('Welcome')}
           />
           <Image
             source={require('../../assets/images/terms-and-conditions.png')}
@@ -58,28 +58,28 @@ export default function TermsAndConditionsScreen({ navigation }) {
                   I read and accept the Terms of Service and Privacy Policy
                 </Text>
               }
-              checked={state.checked}
+              checked={isChecked.checked}
               onPress={() =>
-                setState({
-                  checked: !state.checked,
-                  isButtonEnabled: !state.isButtonEnabled
+                setIsChecked({
+                  checked: !isChecked.checked,
+                  isButtonEnabled: !isChecked.isButtonEnabled
                 })
               }
             />
           </View>
-          {state.isButtonEnabled ? (
+          {isChecked.isButtonEnabled ? (
             <Button
               block
               style={styles.button}
-              onPress={() => navigation.navigate('BiologicalInformation')}
+              onPress={() => navigation.push('BiologicalInformation')}
             >
               <Text>CONTINUE</Text>
             </Button>
           ) : (
-            <Button disabled block style={styles.button}>
-              <Text>CONTINUE</Text>
-            </Button>
-          )}
+              <Button disabled block style={styles.button}>
+                <Text>CONTINUE</Text>
+              </Button>
+            )}
         </View>
       </ScrollView>
     </Fragment>

--- a/screens/WelcomeScreen/WelcomeScreen.js
+++ b/screens/WelcomeScreen/WelcomeScreen.js
@@ -23,7 +23,7 @@ export default function WelcomeScreen({ navigation }) {
         <Button
           block
           style={styles.button}
-          onPress={() => navigation.navigate('TermsAndConditions')}
+          onPress={() => navigation.push('TermsAndConditions')}
         >
           <Text>BEGIN CHECKUP</Text>
         </Button>


### PR DESCRIPTION
## What does this PR do?

- [x] Cleans up navigation stack by using .push and .goBack
- [x] Enables button only when user has answered all questions in QA
- [x] Only show next button when screen has received data from user

### Where should the reviewer start?

- [ ] Welcome screen and look specifically at the navigation portion
Conditional rendering in all screens renders to only allow user to proceed if information is inputed by user:
- [ ] components/GroupSingleQ.js
- [ ] components/SingleQ.js
- [ ] screens/BiologicalInformation/BiologicalInformation.js
- [ ] screens/LocationScreen/LocationScreen.js
- [ ] screens/SelectAge/SelectAge.js
- [ ] screens/SymptomsQA/SymptomsQA.js

#### How should this be manually tested?

Click through the app using `expo start` and try to break navigation

#### Have tests been written for all functionality?

No

#### Screenshots (if appropriate)

<img width="523" alt="Screen Shot 2020-01-07 at 1 11 47 PM" src="https://user-images.githubusercontent.com/25589695/71925863-48b1a300-314f-11ea-91de-6e7051f07436.png">
<img width="523" alt="Screen Shot 2020-01-07 at 1 11 40 PM" src="https://user-images.githubusercontent.com/25589695/71925864-48b1a300-314f-11ea-825a-5d13111e9bb8.png">

#### Additional Notes
