### PR TITLE
Make buttons consistent with icons, add accordion menu to supporting/conflicting evidence and doctor bios.

### DIFF
--- a/components/GroupMultipleQ.js
+++ b/components/GroupMultipleQ.js
@@ -19,7 +19,7 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
               switch (choice.label) {
                 case 'Yes':
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>Yes</Text>
                       <AntDesign
                         key={index}
@@ -39,7 +39,7 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
                   );
                 case 'No':
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>No</Text>
                       <AntDesign
                         key={index}
@@ -59,7 +59,7 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
                   );
                 case `Don't know`:
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>Unsure</Text>
                       <AntDesign
                         key={index}
@@ -114,10 +114,10 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
             <Text>SUBMIT</Text>
           </Button>
         ) : (
-            <Button style={styles.button} disabled block>
-              <Text>SUBMIT</Text>
-            </Button>
-          )}
+          <Button style={styles.button} disabled block>
+            <Text>SUBMIT</Text>
+          </Button>
+        )}
       </Body>
     </Card>
   );
@@ -135,12 +135,12 @@ const styles = StyleSheet.create({
     padding: height * 0.01
   },
   questionCardItem: {
-    shadowColor: "#000",
+    shadowColor: '#000',
     shadowOffset: {
       width: 0,
-      height: 4,
+      height: 4
     },
-    shadowOpacity: 0.30,
+    shadowOpacity: 0.3,
     shadowRadius: 4.65,
     elevation: 8,
     height: height * 0.15,

--- a/components/GroupMultipleQ.js
+++ b/components/GroupMultipleQ.js
@@ -103,7 +103,7 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
     setCheckWho([]);
     answerQuestion(response);
   };
-
+  
   return (
     <Card id={question.question.items[0].id} style={styles.questionCard}>
       <Body style={styles.body}>
@@ -111,11 +111,11 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
         {questions}
         {checkWho.length === question.question.items.length ? (
           <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text>SUBMIT</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         ) : (
           <Button style={styles.button} disabled block>
-            <Text>SUBMIT</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         )}
       </Body>
@@ -129,6 +129,10 @@ const styles = StyleSheet.create({
     marginBottom: height * 0.01,
     marginTop: height * 0.01,
     padding: height * 0.02,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: width * 0.8
   },
   body: {
@@ -137,8 +141,8 @@ const styles = StyleSheet.create({
   questionCardItem: {
     shadowColor: '#000',
     shadowOffset: {
-      width: 0,
-      height: 4
+      width: 5,
+      height: 5
     },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
@@ -149,10 +153,9 @@ const styles = StyleSheet.create({
   },
   questionText: {
     alignSelf: 'flex-start',
-    fontSize: 16,
+    fontSize: width * 0.037,
     fontWeight: 'bold',
     marginBottom: height * 0.02,
-    marginTop: height * 0.01,
     padding: 0
   },
   questionTextHeader: {
@@ -177,6 +180,13 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: height * 0.02,
     marginTop: height * 0.02,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: width * 0.6
+  },
+  buttonText: {
+    fontWeight: 'bold'
   }
 });

--- a/components/GroupMultipleQ.js
+++ b/components/GroupMultipleQ.js
@@ -110,12 +110,12 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
         <Text style={styles.questionTextHeader}>{question.question.text}</Text>
         {questions}
         {checkWho.length === question.question.items.length ? (
-          <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         ) : (
-          <Button style={styles.button} disabled block>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} disabled block>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         )}
       </Body>

--- a/components/GroupMultipleQ.js
+++ b/components/GroupMultipleQ.js
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { Body, Button, Card, Text } from 'native-base';
-import { AntDesign } from '@expo/vector-icons';
+import { AntDesign, Feather } from '@expo/vector-icons';
 
 const height = Dimensions.get('window').height;
 const width = Dimensions.get('window').width;
@@ -103,19 +103,36 @@ export default function GroupMultipleQ({ question, answerQuestion }) {
     setCheckWho([]);
     answerQuestion(response);
   };
-  
+
   return (
     <Card id={question.question.items[0].id} style={styles.questionCard}>
       <Body style={styles.body}>
         <Text style={styles.questionTextHeader}>{question.question.text}</Text>
         {questions}
         {checkWho.length === question.question.items.length ? (
-          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+          <Button
+            rounded
+            style={styles.button}
+            block
+            onPress={() => handleSubmit()}
+          >
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         ) : (
           <Button rounded style={styles.button} disabled block>
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         )}
       </Body>
@@ -177,16 +194,22 @@ const styles = StyleSheet.create({
     width: width * 0.7
   },
   button: {
+    alignItems: 'center',
     alignSelf: 'center',
-    marginBottom: height * 0.02,
-    marginTop: height * 0.02,
+    height: height * 0.07,
+    justifyContent: 'space-around',
+    marginTop: height * 0.05,
     shadowColor: 'black',
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
-    width: width * 0.6
+    width: width * 0.65
   },
   buttonText: {
+    fontSize: height * 0.025,
     fontWeight: 'bold'
+  },
+  icon: {
+    marginRight: height * 0.02
   }
 });

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -19,7 +19,7 @@ export default function GroupSingleQ({ question, answerQuestion }) {
               switch (choice.label) {
                 case 'Yes':
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>Yes</Text>
                       <AntDesign
                         key={index}
@@ -39,7 +39,7 @@ export default function GroupSingleQ({ question, answerQuestion }) {
                   );
                 case 'No':
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>No</Text>
                       <AntDesign
                         key={index}
@@ -59,7 +59,7 @@ export default function GroupSingleQ({ question, answerQuestion }) {
                   );
                 case `Don't know`:
                   return (
-                    <Fragment>
+                    <Fragment key={index}>
                       <Text>Unsure</Text>
                       <AntDesign
                         key={index}
@@ -92,7 +92,7 @@ export default function GroupSingleQ({ question, answerQuestion }) {
     if (id === 'present') {
       IDs = [...checkWho];
       IDs = question.question.items.map(id => {
-        return id = 'absent'
+        return (id = 'absent');
       });
       IDs[index] = id;
       setCheckWho(IDs);
@@ -102,7 +102,7 @@ export default function GroupSingleQ({ question, answerQuestion }) {
       setCheckWho(IDs);
     } else {
       IDs = question.question.items.map(id => {
-        return id = 'unknown'
+        return (id = 'unknown');
       });
       IDs[index] = id;
       setCheckWho(IDs);
@@ -130,10 +130,10 @@ export default function GroupSingleQ({ question, answerQuestion }) {
             <Text>SUBMIT</Text>
           </Button>
         ) : (
-            <Button style={styles.button} disabled block>
-              <Text>SUBMIT</Text>
-            </Button>
-          )}
+          <Button style={styles.button} disabled block>
+            <Text>SUBMIT</Text>
+          </Button>
+        )}
       </Body>
     </Card>
   );
@@ -151,12 +151,12 @@ const styles = StyleSheet.create({
     padding: height * 0.01
   },
   questionCardItem: {
-    shadowColor: "#000",
+    shadowColor: '#000',
     shadowOffset: {
       width: 0,
-      height: 4,
+      height: 4
     },
-    shadowOpacity: 0.30,
+    shadowOpacity: 0.3,
     shadowRadius: 4.65,
     elevation: 8,
     height: height * 0.15,

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -126,12 +126,12 @@ export default function GroupSingleQ({ question, answerQuestion }) {
         <Text style={styles.questionTextHeader}>{question.question.text}</Text>
         {questions}
         {checkWho.length === question.question.items.length ? (
-          <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         ) : (
-          <Button style={styles.button} disabled block>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} disabled block>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         )}
       </Body>

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { Body, Button, Card, Text } from 'native-base';
-import { AntDesign } from '@expo/vector-icons';
+import { AntDesign, Feather } from '@expo/vector-icons';
 
 const height = Dimensions.get('window').height;
 const width = Dimensions.get('window').width;
@@ -126,12 +126,29 @@ export default function GroupSingleQ({ question, answerQuestion }) {
         <Text style={styles.questionTextHeader}>{question.question.text}</Text>
         {questions}
         {checkWho.length === question.question.items.length ? (
-          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+          <Button
+            rounded
+            style={styles.button}
+            block
+            onPress={() => handleSubmit()}
+          >
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         ) : (
           <Button rounded style={styles.button} disabled block>
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         )}
       </Body>
@@ -191,16 +208,22 @@ const styles = StyleSheet.create({
     width: width * 0.7
   },
   button: {
+    alignItems: 'center',
     alignSelf: 'center',
-    marginBottom: height * 0.02,
-    marginTop: height * 0.02,
+    height: height * 0.07,
+    justifyContent: 'space-around',
+    marginTop: height * 0.05,
     shadowColor: 'black',
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
-    width: width * 0.6
+    width: width * 0.65
   },
   buttonText: {
+    fontSize: height * 0.025,
     fontWeight: 'bold'
+  },
+  icon: {
+    marginRight: height * 0.02
   }
 });

--- a/components/GroupSingleQ.js
+++ b/components/GroupSingleQ.js
@@ -127,11 +127,11 @@ export default function GroupSingleQ({ question, answerQuestion }) {
         {questions}
         {checkWho.length === question.question.items.length ? (
           <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text>SUBMIT</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         ) : (
           <Button style={styles.button} disabled block>
-            <Text>SUBMIT</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         )}
       </Body>
@@ -145,17 +145,18 @@ const styles = StyleSheet.create({
     marginBottom: height * 0.01,
     marginTop: height * 0.01,
     padding: height * 0.02,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: width * 0.8
   },
   body: {
     padding: height * 0.01
   },
   questionCardItem: {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 4
-    },
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
     elevation: 8,
@@ -193,6 +194,13 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: height * 0.02,
     marginTop: height * 0.02,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: width * 0.6
+  },
+  buttonText: {
+    fontWeight: 'bold'
   }
 });

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -85,11 +85,11 @@ export default function SingleQ({ question, answerQuestion }) {
         <View style={styles.checkboxes}>{choices}</View>
         {checkWho.length ? (
           <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text>Submit</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         ) : (
           <Button style={styles.button} disabled block>
-            <Text>Submit</Text>
+            <Text style={styles.buttonText}>SUBMIT</Text>
           </Button>
         )}
       </Body>
@@ -102,6 +102,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#f7f7f7',
     marginBottom: height * 0.01,
     marginTop: height * 0.01,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: '80%'
   },
   cardBody: {
@@ -124,5 +128,14 @@ const styles = StyleSheet.create({
     marginBottom: height * 0.02,
     padding: 0,
     width: '90%'
+  },
+  button: {
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+  },
+  buttonText: {
+    fontWeight: 'bold'
   }
 });

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -22,7 +22,7 @@ export default function SingleQ({ question, answerQuestion }) {
     switch (choice.label) {
       case 'Yes':
         return (
-          <Fragment>
+          <Fragment key={index}>
             <Text>Yes</Text>
             <AntDesign
               key={index}
@@ -39,7 +39,7 @@ export default function SingleQ({ question, answerQuestion }) {
         );
       case 'No':
         return (
-          <Fragment>
+          <Fragment key={index}>
             <Text>No</Text>
             <AntDesign
               key={index}
@@ -56,7 +56,7 @@ export default function SingleQ({ question, answerQuestion }) {
         );
       case `Don't know`:
         return (
-          <Fragment>
+          <Fragment key={index}>
             <Text>Unsure</Text>
             <AntDesign
               key={index}
@@ -88,10 +88,10 @@ export default function SingleQ({ question, answerQuestion }) {
             <Text>Submit</Text>
           </Button>
         ) : (
-            <Button style={styles.button} disabled block>
-              <Text>Submit</Text>
-            </Button>
-          )}
+          <Button style={styles.button} disabled block>
+            <Text>Submit</Text>
+          </Button>
+        )}
       </Body>
     </Card>
   );

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -84,12 +84,12 @@ export default function SingleQ({ question, answerQuestion }) {
         <Text style={styles.questionText}>{question.question.text}</Text>
         <View style={styles.checkboxes}>{choices}</View>
         {checkWho.length ? (
-          <Button style={styles.button} block onPress={() => handleSubmit()}>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         ) : (
-          <Button style={styles.button} disabled block>
-            <Text style={styles.buttonText}>SUBMIT</Text>
+          <Button rounded style={styles.button} disabled block>
+            <Text style={styles.buttonText}>Continue</Text>
           </Button>
         )}
       </Body>

--- a/components/SingleQ.js
+++ b/components/SingleQ.js
@@ -1,9 +1,10 @@
 import React, { useState, Fragment } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { Body, Button, Card, Text } from 'native-base';
-import { AntDesign } from '@expo/vector-icons';
+import { AntDesign, Feather } from '@expo/vector-icons';
 
 const height = Dimensions.get('window').height;
+const width = Dimensions.get('window').width;
 
 export default function SingleQ({ question, answerQuestion }) {
   const [checkWho, setCheckWho] = useState([]);
@@ -84,12 +85,29 @@ export default function SingleQ({ question, answerQuestion }) {
         <Text style={styles.questionText}>{question.question.text}</Text>
         <View style={styles.checkboxes}>{choices}</View>
         {checkWho.length ? (
-          <Button rounded style={styles.button} block onPress={() => handleSubmit()}>
+          <Button
+            rounded
+            style={styles.button}
+            block
+            onPress={() => handleSubmit()}
+          >
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         ) : (
           <Button rounded style={styles.button} disabled block>
             <Text style={styles.buttonText}>Continue</Text>
+            <Feather
+              name='arrow-right-circle'
+              size={30}
+              color='white'
+              style={styles.icon}
+            />
           </Button>
         )}
       </Body>
@@ -130,12 +148,22 @@ const styles = StyleSheet.create({
     width: '90%'
   },
   button: {
+    alignItems: 'center',
+    alignSelf: 'center',
+    height: height * 0.07,
+    justifyContent: 'space-around',
+    marginTop: height * 0.05,
     shadowColor: 'black',
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
+    width: width * 0.65
   },
   buttonText: {
+    fontSize: height * 0.025,
     fontWeight: 'bold'
+  },
+  icon: {
+    marginRight: height * 0.02
   }
 });

--- a/components/__tests__/__snapshots__/GroupSingleQ-test.js.snap
+++ b/components/__tests__/__snapshots__/GroupSingleQ-test.js.snap
@@ -28,20 +28,27 @@ exports[`should render correctly 1`] = `
         "shadowRadius": 1.5,
       },
       Object {
+        "backgroundColor": "#f7f7f7",
         "marginBottom": 13.34,
         "marginTop": 13.34,
-        "width": "80%",
+        "padding": 26.68,
+        "width": 600,
       },
     ]
   }
 >
   <View
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "center",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "center",
+          "flex": 1,
+        },
+        Object {
+          "padding": 13.34,
+        },
+      ]
     }
   >
     <Text
@@ -55,7 +62,8 @@ exports[`should render correctly 1`] = `
           Object {
             "alignSelf": "flex-start",
             "flex": 0.5,
-            "fontSize": 16,
+            "fontSize": 20,
+            "fontWeight": "bold",
             "marginBottom": 26.68,
             "marginTop": 13.34,
             "padding": 0,
@@ -92,20 +100,33 @@ exports[`should render correctly 1`] = `
             "shadowRadius": 1.5,
           },
           Object {
+            "elevation": 8,
             "height": 200.1,
             "marginBottom": 13.34,
             "marginTop": 13.34,
+            "shadowColor": "#000",
+            "shadowOffset": Object {
+              "height": 4,
+              "width": 0,
+            },
+            "shadowOpacity": 0.3,
+            "shadowRadius": 4.65,
           },
         ]
       }
     >
       <View
         style={
-          Object {
-            "alignItems": "center",
-            "alignSelf": "center",
-            "flex": 1,
-          }
+          Array [
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "flex": 1,
+            },
+            Object {
+              "padding": 13.34,
+            },
+          ]
         }
       >
         <Text
@@ -118,8 +139,8 @@ exports[`should render correctly 1`] = `
               },
               Object {
                 "alignSelf": "flex-start",
-                "flex": 0.5,
                 "fontSize": 16,
+                "fontWeight": "bold",
                 "marginBottom": 26.68,
                 "marginTop": 13.34,
                 "padding": 0,
@@ -137,7 +158,7 @@ exports[`should render correctly 1`] = `
               "justifyContent": "space-around",
               "marginBottom": 26.68,
               "padding": 0,
-              "width": "90%",
+              "width": 525,
             }
           }
         >
@@ -184,7 +205,7 @@ exports[`should render correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "alignSelf": "stretch",
+          "alignSelf": "center",
           "backgroundColor": "#b5b5b5",
           "borderBottomWidth": null,
           "borderColor": "#007aff",
@@ -197,7 +218,7 @@ exports[`should render correctly 1`] = `
           "flexDirection": "row",
           "height": 45,
           "justifyContent": "center",
-          "marginBottom": 53.36,
+          "marginBottom": 26.68,
           "marginTop": 26.68,
           "opacity": 1,
           "paddingBottom": 6,
@@ -206,6 +227,7 @@ exports[`should render correctly 1`] = `
           "shadowOffset": undefined,
           "shadowOpacity": undefined,
           "shadowRadius": undefined,
+          "width": 450,
         }
       }
     >

--- a/components/__tests__/__snapshots__/SingleQ-test.js.snap
+++ b/components/__tests__/__snapshots__/SingleQ-test.js.snap
@@ -28,6 +28,7 @@ exports[`should render correctly 1`] = `
         "shadowRadius": 1.5,
       },
       Object {
+        "backgroundColor": "#f7f7f7",
         "marginBottom": 13.34,
         "marginTop": 13.34,
         "width": "80%",

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -6,17 +6,25 @@ import {
   StyleSheet,
   View
 } from 'react-native';
-import { Body, Button, Card, CardItem, Text } from 'native-base';
+import {
+  Accordion,
+  Body,
+  Button,
+  Card,
+  CardItem,
+  Icon,
+  Text
+} from 'native-base';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Header } from '../../components/Header';
 import { compileReport, formatPhoneNumber } from '../../utils/helpers/helpers';
-import { isLoaded, isLoading } from 'expo-font';
 import { getDistanceToDoctor } from '../../utils/apiCalls/DistanceToDoctor/getDistanceToDoctor';
 import { getAllProviders } from '../../utils/apiCalls/DoctorsAndProviders/getAllProviders';
 import { getDoctorsByLocation } from '../../utils/apiCalls/DoctorsAndProviders/getDoctorsByLocation';
 import { getDoctorsForProviderByLocation } from '../../utils/apiCalls/DoctorsAndProviders/getDoctorsForProviderByLocation';
 
 const height = Dimensions.get('window').height;
+const width = Dimensions.get('window').width;
 
 export default function DoctorsScreen({ navigation }) {
   const {
@@ -87,12 +95,54 @@ export default function DoctorsScreen({ navigation }) {
     doctors
   );
 
+  const renderHeader = (item, expanded) => {
+    return (
+      <View
+        style={{
+          flexDirection: 'row',
+          padding: 10,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: '#004EFF',
+          width: '100%'
+        }}
+      >
+        <Text style={{ fontWeight: '600', color: '#fff' }}> {item.title}</Text>
+        {expanded ? (
+          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-up' />
+        ) : (
+          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-down' />
+        )}
+      </View>
+    );
+  };
+  const renderContent = item => {
+    return (
+      <Text
+        style={{
+          backgroundColor: '#fff',
+          padding: 10,
+          fontStyle: 'italic'
+        }}
+      >
+        {item.content}
+      </Text>
+    );
+  };
+
   const nearbyPractices = doctors.map((doctor, index) => {
     return (
       <Card key={index}>
         <CardItem>
           <Body>
-            <Text style={styles.doctorName}>{doctor.practice.name}</Text>
+            <Accordion
+              dataArray={[
+                { title: doctor.practice.name, content: doctor.profile.bio }
+              ]}
+              renderHeader={renderHeader}
+              renderContent={renderContent}
+              style={styles.accordion}
+            />
             <Text>{formatPhoneNumber(doctor.practice.phone)}</Text>
           </Body>
         </CardItem>
@@ -176,7 +226,7 @@ export default function DoctorsScreen({ navigation }) {
                     })
                   }
                 >
-                  <Text style={styles.buttonText}>Email Report</Text>
+                  <Text style={styles.buttonText}>EMAIL REPORT</Text>
                 </Button>
               </Fragment>
             )}
@@ -241,5 +291,10 @@ const styles = StyleSheet.create({
   },
   noDoctors: {
     fontSize: 24
+  },
+  accordion: {
+    alignSelf: 'center',
+    marginBottom: height * 0.01,
+    width: width * 0.87
   }
 });

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -278,7 +278,8 @@ const styles = StyleSheet.create({
     width: '75%'
   },
   buttonText: {
-    fontSize: 18
+    fontSize: 18,
+    fontWeight: 'bold'
   },
   picker: {
     height: height * 0.22,

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -103,7 +103,7 @@ export default function DoctorsScreen({ navigation }) {
           padding: 10,
           justifyContent: 'space-between',
           alignItems: 'center',
-          backgroundColor: '#004EFF',
+          backgroundColor: '#0960FF',
           width: '100%'
         }}
       >

--- a/screens/DoctorsScreen/DoctorsScreen.js
+++ b/screens/DoctorsScreen/DoctorsScreen.js
@@ -16,6 +16,7 @@ import {
   Text
 } from 'native-base';
 import { ScrollView } from 'react-native-gesture-handler';
+import { Ionicons } from '@expo/vector-icons';
 import { Header } from '../../components/Header';
 import { compileReport, formatPhoneNumber } from '../../utils/helpers/helpers';
 import { getDistanceToDoctor } from '../../utils/apiCalls/DistanceToDoctor/getDistanceToDoctor';
@@ -107,11 +108,11 @@ export default function DoctorsScreen({ navigation }) {
           width: '100%'
         }}
       >
-        <Text style={{ fontWeight: '600', color: '#fff' }}> {item.title}</Text>
+        <Text style={{ fontWeight: '700', color: '#fff' }}> {item.title}</Text>
         {expanded ? (
-          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-up' />
+          <Icon style={{ fontSize: 24, color: '#fff' }} name='arrow-up' />
         ) : (
-          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-down' />
+          <Icon style={{ fontSize: 24, color: '#fff' }} name='arrow-down' />
         )}
       </View>
     );
@@ -132,7 +133,7 @@ export default function DoctorsScreen({ navigation }) {
 
   const nearbyPractices = doctors.map((doctor, index) => {
     return (
-      <Card key={index}>
+      <Card key={index} style={styles.doctorCard}>
         <CardItem>
           <Body>
             <Accordion
@@ -216,7 +217,7 @@ export default function DoctorsScreen({ navigation }) {
                   )}
                 </ScrollView>
                 <Button
-                  block
+                  rounded
                   style={styles.button}
                   onPress={() =>
                     navigation.push('Email', {
@@ -226,7 +227,13 @@ export default function DoctorsScreen({ navigation }) {
                     })
                   }
                 >
-                  <Text style={styles.buttonText}>EMAIL REPORT</Text>
+                  <Text style={styles.buttonText}>Email Report</Text>
+                    <Ionicons
+                      name='ios-send'
+                      style={styles.icon}
+                      size={26}
+                      color='white'
+                    />
                 </Button>
               </Fragment>
             )}
@@ -273,12 +280,18 @@ const styles = StyleSheet.create({
     fontWeight: 'bold'
   },
   button: {
-    alignSelf: 'center',
-    marginTop: height * 0.04,
-    width: '75%'
+    alignItems: 'center',
+    height: height * 0.07,
+    justifyContent: 'space-around',
+    marginTop: height * 0.05,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    width: width * 0.65
   },
   buttonText: {
-    fontSize: 18,
+    fontSize: height * 0.025,
     fontWeight: 'bold'
   },
   picker: {
@@ -297,5 +310,17 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: height * 0.01,
     width: width * 0.87
-  }
+  },
+  doctorCard: {
+    alignSelf: 'center',
+    marginBottom: height * 0.01,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    width: '95%'
+  },
+  icon: {
+    marginRight: height * 0.02
+  },
 });

--- a/screens/EmailScreen/EmailScreen.js
+++ b/screens/EmailScreen/EmailScreen.js
@@ -160,6 +160,10 @@ const styles = StyleSheet.create({
     height: height * 0.07,
     justifyContent: 'space-around',
     marginTop: height * 0.05,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: width * 0.65
   },
   buttonText: {

--- a/screens/EmailScreen/EmailScreen.js
+++ b/screens/EmailScreen/EmailScreen.js
@@ -134,10 +134,6 @@ const styles = StyleSheet.create({
     paddingBottom: height * 0.075,
     width: width
   },
-  contentContainer: {
-    alignItems: 'center',
-    flex: 1
-  },
   close: {
     alignSelf: 'flex-end',
     marginRight: height * 0.02,
@@ -148,14 +144,16 @@ const styles = StyleSheet.create({
     width: width * 0.8
   },
   input: {
-    fontSize: height * 0.02,
+    fontSize: width * 0.04,
     textAlign: 'center',
     width: width * 0.6
   },
   title: {
-    fontSize: height * 0.04,
+    fontSize: width * 0.07,
     fontWeight: 'bold',
-    paddingTop: height * 0.025
+    paddingTop: height * 0.01,
+    textAlign: 'center',
+    width: width * 0.9
   },
   button: {
     alignItems: 'center',
@@ -188,6 +186,7 @@ const styles = StyleSheet.create({
   },
   thankYou: {
     marginLeft: height * 0.02,
-    marginRight: height * 0.02
+    marginRight: height * 0.02,
+    textAlign: 'center'
   }
 });

--- a/screens/EmailScreen/EmailScreen.js
+++ b/screens/EmailScreen/EmailScreen.js
@@ -8,6 +8,7 @@ import * as EmailValidator from 'email-validator';
 import { sendEmailReport } from '../../utils/apiCalls/SendEmail/sendEmailReport';
 
 const height = Dimensions.get('window').height;
+const width = Dimensions.get('window').width;
 
 export default function EmailScreen({ navigation }) {
   const { location, report, stateAbbreviation } = navigation.state.params;
@@ -64,62 +65,62 @@ export default function EmailScreen({ navigation }) {
             </Button>
           </Fragment>
         ) : (
-            <Fragment>
-              <Item style={styles.item}>
-                <Input
-                  placeholder='Enter your email address'
-                  style={styles.input}
-                  autoCapitalize='none'
-                  onChangeText={text => validateEmail(text)}
-                />
-              </Item>
-              <View style={styles.buttonContainer}>
-                {enabled ? (
-                  <Button
-                    rounded
-                    style={styles.button}
-                    onPress={() => sendEmail()}
-                  >
-                    <Text style={styles.buttonText}>Send Report</Text>
-                    <Ionicons
-                      name='ios-send'
-                      style={styles.icon}
-                      size={26}
-                      color='white'
-                    />
-                  </Button>
-                ) : (
-                    <Button
-                      disabled
-                      rounded
-                      style={styles.button}
-                      onPress={() => sendEmail()}
-                    >
-                      <Text style={styles.buttonText}>Send Report</Text>
-                      <Ionicons
-                        name='ios-send'
-                        style={styles.icon}
-                        size={26}
-                        color='white'
-                      />
-                    </Button>
-                  )}
+          <Fragment>
+            <Item style={styles.item}>
+              <Input
+                placeholder='Enter your email address'
+                style={styles.input}
+                autoCapitalize='none'
+                onChangeText={text => validateEmail(text)}
+              />
+            </Item>
+            <View style={styles.buttonContainer}>
+              {enabled ? (
                 <Button
                   rounded
                   style={styles.button}
-                  onPress={() => navigation.push('Welcome')}
+                  onPress={() => sendEmail()}
                 >
-                  <Text style={styles.buttonText}>New Checkup</Text>
-                  <MaterialCommunityIcons
-                    name='stethoscope'
+                  <Text style={styles.buttonText}>Send Report</Text>
+                  <Ionicons
+                    name='ios-send'
                     style={styles.icon}
                     size={26}
                     color='white'
                   />
                 </Button>
-              </View>
-            </Fragment>
-          )}
+              ) : (
+                <Button
+                  disabled
+                  rounded
+                  style={styles.button}
+                  onPress={() => sendEmail()}
+                >
+                  <Text style={styles.buttonText}>Send Report</Text>
+                  <Ionicons
+                    name='ios-send'
+                    style={styles.icon}
+                    size={26}
+                    color='white'
+                  />
+                </Button>
+              )}
+              <Button
+                rounded
+                style={styles.button}
+                onPress={() => navigation.push('Welcome')}
+              >
+                <Text style={styles.buttonText}>New Checkup</Text>
+                <MaterialCommunityIcons
+                  name='stethoscope'
+                  style={styles.icon}
+                  size={26}
+                  color='white'
+                />
+              </Button>
+            </View>
+          </Fragment>
+        )}
       </View>
     </Fragment>
   );
@@ -131,7 +132,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'space-between',
     paddingBottom: height * 0.075,
-    width: '100%'
+    width: width
   },
   contentContainer: {
     alignItems: 'center',
@@ -144,15 +145,15 @@ const styles = StyleSheet.create({
   },
   item: {
     marginBottom: height * 0.1,
-    width: '80%'
+    width: width * 0.8
   },
   input: {
-    fontSize: 16,
+    fontSize: height * 0.02,
     textAlign: 'center',
-    width: '60%'
+    width: width * 0.6
   },
   title: {
-    fontSize: 36,
+    fontSize: height * 0.04,
     fontWeight: 'bold',
     paddingTop: height * 0.025
   },
@@ -161,10 +162,10 @@ const styles = StyleSheet.create({
     height: height * 0.07,
     justifyContent: 'space-around',
     marginTop: height * 0.05,
-    width: '60%'
+    width: width * 0.65
   },
   buttonText: {
-    fontSize: 20,
+    fontSize: height * 0.025,
     fontWeight: 'bold'
   },
   buttonContainer: {
@@ -178,11 +179,11 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     height: height * 0.17,
     marginBottom: height * 0.01,
-    marginTop: height * 0.04,
+    marginTop: height * 0.03,
     width: height * 0.17
   },
   response: {
-    fontSize: 24,
+    fontSize: width * 0.06,
     fontWeight: 'bold'
   },
   thankYou: {

--- a/screens/LocationScreen/LocationScreen.js
+++ b/screens/LocationScreen/LocationScreen.js
@@ -45,7 +45,7 @@ export default function LocationScreen({ navigation }) {
             onPress={() => navigation.goBack()}
           />
           <View style={styles.childContainer}>
-            <Text style={styles.title}>What state are you located in?</Text>
+            <Text style={styles.title}>Which state are you located in?</Text>
             <Entypo
               name='location-pin'
               style={styles.pin}

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -235,7 +235,7 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     flex: 1,
-    marginBottom: height * 0.05,
+    marginBottom: height * 0.04,
     marginTop: height * 0.02,
     width: '100%'
   },
@@ -252,26 +252,32 @@ const styles = StyleSheet.create({
     fontSize: 16,
     padding: 0
   },
-  card: {
-    flex: 1,
-    padding: 0,
-    width: '100%'
-  },
   question: {
     width: '80%'
   },
   conditionCard: {
+    alignSelf: 'center',
     flex: 1,
-    width: '100%'
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    width: '95%'
   },
   secondaryCondition: {
     fontSize: 16,
     fontWeight: 'bold',
-    marginBottom: height * 0.01
+    marginBottom: height * 0.01,
+    marginTop: height * 0.002
   },
   topDiagnosis: {
+    alignSelf: 'center',
     flex: 1,
-    width: '100%'
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    width: '95%'
   },
   btnText: {
     textAlign: 'center',
@@ -284,13 +290,13 @@ const styles = StyleSheet.create({
     marginTop: height * 0.01,
     width: '100%'
   },
-  Btn: {
-    padding: 10,
-    backgroundColor: '#004EFF'
-  },
   button: {
     alignSelf: 'center',
     marginBottom: height * 0.05,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: '80%'
   },
   buttonText: {

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -205,7 +205,7 @@ export default function SymptomsQA({ navigation }) {
         {getTopDiagnoses()}
       </ScrollView>
       <Button
-        block
+        rounded
         style={styles.button}
         onPress={() =>
           navigation.push('Doctors', {
@@ -218,7 +218,7 @@ export default function SymptomsQA({ navigation }) {
           })
         }
       >
-        <Text style={styles.buttonText}>FIND DOCTORS</Text>
+        <Text style={styles.buttonText}>Find Doctors</Text>
       </Button>
     </View>
   );

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -15,6 +15,7 @@ import {
   Icon,
   Text
 } from 'native-base';
+import { Entypo } from '@expo/vector-icons';
 import * as Progress from 'react-native-progress';
 import { Header } from '../../components/Header';
 import { specifyTargetCondition } from '../../utils/helpers/helpers';
@@ -23,6 +24,7 @@ import { getExplanation } from '../../utils/apiCalls/Infermedica/getExplanation'
 import { getConditionById } from '../../utils/apiCalls/Conditions/getConditionById';
 
 const height = Dimensions.get('window').height;
+const width = Dimensions.get('window').width;
 
 export default function SymptomsQA({ navigation }) {
   let {
@@ -219,6 +221,12 @@ export default function SymptomsQA({ navigation }) {
         }
       >
         <Text style={styles.buttonText}>Find Doctors</Text>
+        <Entypo
+          name='location-pin'
+          style={styles.icon}
+          size={36}
+          color='white'
+        />
       </Button>
     </View>
   );
@@ -291,15 +299,22 @@ const styles = StyleSheet.create({
     width: '100%'
   },
   button: {
-    alignSelf: 'center',
-    marginBottom: height * 0.05,
-    shadowColor: 'black',
-    shadowOffset: { width: 5, height: 5 },
-    shadowOpacity: 0.3,
-    shadowRadius: 4.65,
-    width: '80%'
+      alignSelf: 'center',
+      height: height * 0.07,
+      justifyContent: 'space-around',
+      marginBottom: height * 0.02,
+      marginTop: -height * 0.25,
+      shadowColor: 'black',
+      shadowOffset: { width: 5, height: 5 },
+      shadowOpacity: 0.3,
+      shadowRadius: 4.65,
+      width: width * 0.65
   },
   buttonText: {
+    fontSize: height * 0.025,
     fontWeight: 'bold'
+  },
+  icon: {
+    marginRight: height * 0.02
   }
 });

--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -4,7 +4,6 @@ import {
   StyleSheet,
   SafeAreaView,
   View,
-  LayoutAnimation,
   FlatList
 } from 'react-native';
 import {
@@ -219,7 +218,7 @@ export default function SymptomsQA({ navigation }) {
           })
         }
       >
-        <Text>FIND DOCTORS</Text>
+        <Text style={styles.buttonText}>FIND DOCTORS</Text>
       </Button>
     </View>
   );
@@ -293,5 +292,8 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: height * 0.05,
     width: '80%'
+  },
+  buttonText: {
+    fontWeight: 'bold'
   }
 });

--- a/screens/RiskFactors/RiskFactors.js
+++ b/screens/RiskFactors/RiskFactors.js
@@ -158,7 +158,7 @@ const styles = StyleSheet.create({
     width: '100%'
   },
   questionText: {
-    fontSize: width * 0.030,
+    fontSize: width * 0.035,
   },
   riskFactorCard: {
     alignItems: 'center',
@@ -168,10 +168,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     padding: 10,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: '75%'
   },
   checkboxes: {
-    // alignContent: 'center',
     flex: 0.15,
     flexDirection: 'row',
     fontSize: 12,

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -103,7 +103,7 @@ export default function SymptomsScreen({ navigation }) {
         <View style={styles.contentContainer}>
           <Entypo
             name='chevron-thin-up'
-            size={36}
+            size={50}
             color='white'
             onPress={() => navigation.goBack()}
           />
@@ -134,7 +134,7 @@ export default function SymptomsScreen({ navigation }) {
           {symptoms.length >= 3 && (
             <Entypo
               name='chevron-thin-down'
-              size={36}
+              size={50}
               color='white'
               onPress={() => sendInitialSymptoms()}
             />
@@ -185,9 +185,9 @@ const styles = StyleSheet.create({
   },
   title: {
     color: 'white',
-    fontSize: 36,
+    fontSize: height * 0.04,
     fontWeight: 'bold',
-    paddingTop: height * 0.025
+    paddingTop: height * 0.01
   },
   searchResultsContainer: {
     marginLeft: '5%',
@@ -208,7 +208,11 @@ const styles = StyleSheet.create({
     marginLeft: height * 0.01,
     marginTop: height * 0.01,
     maxWidth: width * 0.9,
-    padding: height * 0.01
+    padding: height * 0.01,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
   },
   searchResults: {
     alignSelf: 'center',
@@ -225,14 +229,18 @@ const styles = StyleSheet.create({
   },
   checkboxes: {
     alignItems: 'center',
-    backgroundColor: 'rgba(256, 256, 256, 0.7)',
+    backgroundColor: 'rgba(256, 256, 256, 0.9)',
     borderColor: 'grey',
     borderRadius: 15,
     height: height * 0.13,
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginTop: height * 0.02,
-    padding: 10
+    padding: 10,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
   },
   delete: {
     marginLeft: 10

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -107,7 +107,7 @@ export default function SymptomsScreen({ navigation }) {
             color='white'
             onPress={() => navigation.goBack()}
           />
-          <Text style={styles.title}>Symptoms</Text>
+          <Text style={styles.title}>Search Symptoms</Text>
           <Item style={styles.searchBox}>
             <Input
               placeholder='Search all symptoms'

--- a/screens/SelectAge/SelectAge.js
+++ b/screens/SelectAge/SelectAge.js
@@ -22,8 +22,6 @@ export default function SelectAge({ navigation }) {
     );
   });
 
-  console.log(ages)
-
   return (
     <View style={styles.container}>
       <LinearGradient

--- a/screens/SymptomsQA/SymptomsQA.js
+++ b/screens/SymptomsQA/SymptomsQA.js
@@ -83,7 +83,7 @@ export default function SymptomsQA({ navigation }) {
         <View style={styles.contentContainer}>
           <Entypo
             name='chevron-thin-up'
-            size={36}
+            size={50}
             color='white'
             onPress={() => navigation.goBack()}
           />

--- a/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
+++ b/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
     fontSize: height * 0.018,
     lineHeight: height * 0.035,
     marginBottom: height * 0.02,
-    marginTop: height * 0.02
+    marginTop: height * 0.02,
   },
   agreement: {
     alignSelf: 'flex-start',
@@ -134,6 +134,10 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     marginBottom: height * 0.02,
     marginTop: -height * 0.25,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: '75%'
   },
   checkbox: {

--- a/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
+++ b/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
@@ -67,11 +67,11 @@ export default function TermsAndConditionsScreen({ navigation }) {
               style={styles.button}
               onPress={() => navigation.push('BiologicalInformation')}
             >
-              <Text>CONTINUE</Text>
+              <Text style={styles.buttonText}>CONTINUE</Text>
             </Button>
           ) : (
               <Button disabled block style={styles.button}>
-                <Text>CONTINUE</Text>
+                <Text style={styles.buttonText}>CONTINUE</Text>
               </Button>
             )}
         </View>
@@ -139,5 +139,8 @@ const styles = StyleSheet.create({
   checkbox: {
     height: 30,
     width: 30
-  }
+  },
+  buttonText: {
+  fontWeight: 'bold'
+}
 });

--- a/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
+++ b/screens/TermsAndConditionsScreen/TermsAndConditionsScreen.js
@@ -9,7 +9,7 @@ import {
 import { Button, Text } from 'native-base';
 import { Header } from '../../components/Header';
 import { ScrollView } from 'react-native-gesture-handler';
-import { AntDesign } from '@expo/vector-icons';
+import { AntDesign, Feather } from '@expo/vector-icons';
 import Checkbox from '../../components/Checkbox';
 
 const height = Dimensions.get('window').height;
@@ -63,17 +63,29 @@ export default function TermsAndConditionsScreen({ navigation }) {
           </View>
           {enabled ? (
             <Button
-              block
+              rounded
               style={styles.button}
               onPress={() => navigation.push('BiologicalInformation')}
             >
-              <Text style={styles.buttonText}>CONTINUE</Text>
+              <Text style={styles.buttonText}>Continue</Text>
+              <Feather
+                name='arrow-right-circle'
+                size={30}
+                color='white'
+                style={styles.nextIcon}
+              />
             </Button>
           ) : (
-              <Button disabled block style={styles.button}>
-                <Text style={styles.buttonText}>CONTINUE</Text>
-              </Button>
-            )}
+            <Button disabled rounded style={styles.button}>
+              <Text style={styles.buttonText}>Continue</Text>
+              <Feather
+                name='arrow-right-circle'
+                size={30}
+                color='white'
+                style={styles.nextIcon}
+              />
+            </Button>
+          )}
         </View>
       </View>
     </Fragment>
@@ -123,7 +135,7 @@ const styles = StyleSheet.create({
     fontSize: height * 0.018,
     lineHeight: height * 0.035,
     marginBottom: height * 0.02,
-    marginTop: height * 0.02,
+    marginTop: height * 0.02
   },
   agreement: {
     alignSelf: 'flex-start',
@@ -132,19 +144,25 @@ const styles = StyleSheet.create({
   },
   button: {
     alignSelf: 'center',
+    height: height * 0.07,
+    justifyContent: 'space-around',
     marginBottom: height * 0.02,
     marginTop: -height * 0.25,
     shadowColor: 'black',
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
-    width: '75%'
+    width: width * 0.65
   },
   checkbox: {
     height: 30,
     width: 30
   },
   buttonText: {
-  fontWeight: 'bold'
-}
+    fontSize: height * 0.025,
+    fontWeight: 'bold'
+  },
+  nextIcon: {
+    marginRight: height * 0.02
+  }
 });

--- a/screens/WelcomeScreen/WelcomeScreen.js
+++ b/screens/WelcomeScreen/WelcomeScreen.js
@@ -6,12 +6,11 @@ import { Header } from '../../components/Header';
 const height = Dimensions.get('window').height;
 const width = Dimensions.get('window').width;
 
-
 export default function WelcomeScreen({ navigation }) {
   return (
     <View style={styles.container}>
       <Header />
-      <View style={styles.contentContainer} >
+      <View style={styles.contentContainer}>
         <Image
           source={require('../../assets/images/doctor.png')}
           style={styles.icon}
@@ -19,16 +18,16 @@ export default function WelcomeScreen({ navigation }) {
         <View style={styles.welcome}>
           <Text style={styles.greeting}>Hello!</Text>
           <Text style={styles.message}>
-            Welcome to MeMD, a mobile platform designed to help diagnose conditions
-            and locate potential doctors. Please click BEGIN CHECKUP to start your health
-            checkup.
-        </Text>
+            Welcome to MeMD, a mobile platform designed to help diagnose
+            conditions and locate potential doctors. Please click BEGIN CHECKUP
+            to start your health checkup.
+          </Text>
           <Button
             block
             style={styles.button}
             onPress={() => navigation.push('TermsAndConditions')}
           >
-            <Text>BEGIN CHECKUP</Text>
+            <Text style={styles.buttonText}>BEGIN CHECKUP</Text>
           </Button>
         </View>
       </View>
@@ -43,8 +42,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingBottom: height * 0.075
   },
-  contentContainer: {
-  },
+  contentContainer: {},
   icon: {
     alignSelf: 'center',
     borderWidth: 0,
@@ -57,7 +55,7 @@ const styles = StyleSheet.create({
   greeting: {
     fontSize: 40,
     fontWeight: 'bold',
-    margin: width * 0.06,
+    margin: width * 0.06
   },
   welcome: {
     textAlign: 'center'
@@ -65,11 +63,15 @@ const styles = StyleSheet.create({
   message: {
     alignSelf: 'center',
     padding: width * 0.06,
-    fontSize: 22,
+    fontSize: 22
   },
   button: {
     alignSelf: 'center',
+    fontWeight: 'bold',
     marginTop: height * 0.02,
     width: '75%'
+  },
+  buttonText: {
+    fontWeight: 'bold'
   }
 });

--- a/screens/WelcomeScreen/WelcomeScreen.js
+++ b/screens/WelcomeScreen/WelcomeScreen.js
@@ -69,6 +69,10 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     fontWeight: 'bold',
     marginTop: height * 0.02,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
     width: '75%'
   },
   buttonText: {

--- a/screens/WelcomeScreen/WelcomeScreen.js
+++ b/screens/WelcomeScreen/WelcomeScreen.js
@@ -28,7 +28,7 @@ export default function WelcomeScreen({ navigation }) {
             style={styles.button}
             onPress={() => navigation.push('TermsAndConditions')}
           >
-            <Text style={styles.buttonText}>New Checkup</Text>
+            <Text style={styles.buttonText}>Start Checkup</Text>
             <MaterialCommunityIcons
               name='stethoscope'
               style={styles.buttonIcon}
@@ -82,13 +82,13 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
-    width: width * 0.65,
+    width: width * 0.65
   },
   buttonText: {
     fontSize: height * 0.025,
     fontWeight: 'bold'
   },
   buttonIcon: {
-      marginRight: height * 0.02
+    marginRight: height * 0.02
   }
 });

--- a/screens/WelcomeScreen/WelcomeScreen.js
+++ b/screens/WelcomeScreen/WelcomeScreen.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Dimensions, Image, StyleSheet, View } from 'react-native';
 import { Button, Text } from 'native-base';
 import { Header } from '../../components/Header';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 const height = Dimensions.get('window').height;
 const width = Dimensions.get('window').width;
@@ -19,15 +20,21 @@ export default function WelcomeScreen({ navigation }) {
           <Text style={styles.greeting}>Hello!</Text>
           <Text style={styles.message}>
             Welcome to MeMD, a mobile platform designed to help diagnose
-            conditions and locate potential doctors. Please click BEGIN CHECKUP
+            conditions and locate potential doctors. Please click Start Checkup
             to start your health checkup.
           </Text>
           <Button
-            block
+            rounded
             style={styles.button}
             onPress={() => navigation.push('TermsAndConditions')}
           >
-            <Text style={styles.buttonText}>BEGIN CHECKUP</Text>
+            <Text style={styles.buttonText}>New Checkup</Text>
+            <MaterialCommunityIcons
+              name='stethoscope'
+              style={styles.buttonIcon}
+              size={26}
+              color='white'
+            />
           </Button>
         </View>
       </View>
@@ -68,14 +75,20 @@ const styles = StyleSheet.create({
   button: {
     alignSelf: 'center',
     fontWeight: 'bold',
+    height: height * 0.07,
+    justifyContent: 'space-around',
     marginTop: height * 0.02,
     shadowColor: 'black',
     shadowOffset: { width: 5, height: 5 },
     shadowOpacity: 0.3,
     shadowRadius: 4.65,
-    width: '75%'
+    width: width * 0.65,
   },
   buttonText: {
+    fontSize: height * 0.025,
     fontWeight: 'bold'
+  },
+  buttonIcon: {
+      marginRight: height * 0.02
   }
 });

--- a/screens/__tests__/__snapshots__/TermsAndConditionsScreen-test.js.snap
+++ b/screens/__tests__/__snapshots__/TermsAndConditionsScreen-test.js.snap
@@ -139,69 +139,87 @@ Array [
         </View>
         <View>
           <View
+            accessible={true}
+            focusable={true}
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "backgroundColor": "#fff",
-                  "borderBottomWidth": 0.5,
-                  "borderColor": "#ccc",
-                  "borderLeftWidth": 0.5,
-                  "borderRadius": 2,
-                  "borderRightWidth": 0.5,
-                  "borderTopWidth": 0.5,
-                  "elevation": 3,
-                  "flexWrap": "nowrap",
-                  "marginBottom": 5,
-                  "marginLeft": 2,
-                  "marginRight": 2,
-                  "marginTop": 5,
-                  "shadowColor": "#000",
-                  "shadowOffset": Object {
-                    "height": 2,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.1,
-                  "shadowRadius": 1.5,
-                },
-                Object {
-                  "flex": 0.2,
-                  "justifyContent": "space-evenly",
-                  "width": 690,
-                },
-              ]
+              Object {
+                "opacity": 1,
+              }
             }
           >
             <View
               style={
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "alignSelf": "center",
-                    "flex": 1,
+                    "backgroundColor": "#fff",
+                    "borderBottomWidth": 0.5,
+                    "borderColor": "#ccc",
+                    "borderLeftWidth": 0.5,
+                    "borderRadius": 2,
+                    "borderRightWidth": 0.5,
+                    "borderTopWidth": 0.5,
+                    "elevation": 3,
+                    "flexWrap": "nowrap",
+                    "marginBottom": 5,
+                    "marginLeft": 2,
+                    "marginRight": 2,
+                    "marginTop": 5,
+                    "shadowColor": "#000",
+                    "shadowOffset": Object {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.1,
+                    "shadowRadius": 1.5,
                   },
                   Object {
-                    "alignItems": "center",
-                    "flex": 0.3,
-                    "flexDirection": "row",
+                    "flex": 0.2,
                     "justifyContent": "space-evenly",
-                    "width": "100%",
+                    "width": 690,
                   },
                 ]
               }
             >
-              <Text />
-              <Text
+              <View
                 style={
-                  Object {
-                    "color": "#000",
-                    "fontFamily": "System",
-                    "fontSize": 16,
-                  }
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "alignSelf": "center",
+                      "flex": 1,
+                    },
+                    Object {
+                      "alignItems": "center",
+                      "flex": 0.3,
+                      "flexDirection": "row",
+                      "justifyContent": "space-evenly",
+                      "width": "100%",
+                    },
+                  ]
                 }
-                uppercase={false}
               >
-                I have read and accept the Terms of Service
-              </Text>
+                <Text />
+                <Text
+                  style={
+                    Object {
+                      "color": "#000",
+                      "fontFamily": "System",
+                      "fontSize": 16,
+                    }
+                  }
+                  uppercase={false}
+                >
+                  I have read and accept the Terms of Service
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -233,7 +251,6 @@ Array [
               "height": 45,
               "justifyContent": "center",
               "marginBottom": 40.019999999999996,
-              "marginTop": 26.68,
               "opacity": 1,
               "paddingBottom": 6,
               "paddingTop": 6,


### PR DESCRIPTION
## What does this PR do?
- [x] Make `EmailScreen` styling more dynamic utilizing width and height dimensions properties
- [x] Adjust `EmailScreen` input positioning to render above keyboard
- [x] Adjust email confirmation message to render in the center of the screen
- [x] Add accordion menu to `DoctorsScreen` to display doctor bio for each doctor
- [x] Add accordion menus to `Results` screen to display supporting and conflicting symptoms for most probable condition
- [x] Add key to `SingleQ`,` GroupSingle` and `GroupMultiple` question components to get rid of error
- [x] Make font weight on buttons bold
- [x] Add subtle box shadow to all card components and buttons
- [x] Change 'Submit' to 'Continue' on `Terms and Conditions`, `SingleQ`, `GroupSingle` and `GroupMultiple` question components
- [x] Add icons to all buttons for better user experience - signifier and affordances
### Where should the reviewer start?
- [x] In `DoctorsScreen` on line 99 through the rest of the file
- [x] In `Results` on line 60 through the rest of the file
- [x] The rest of the files with buttons all have the exact same styling changes that look roughly like this: 
```
  button: {
    alignItems: 'center',
    alignSelf: 'center',
    height: height * 0.07,
    justifyContent: 'space-around',
    marginBottom: height * 0.02,
    marginTop: height * 0.05,
    shadowColor: 'black',
    shadowOffset: { width: 5, height: 5 },
    shadowOpacity: 0.3,
    shadowRadius: 4.65,
    width: width * 0.65
  },
  buttonText: {
    fontSize: height * 0.025,
    fontWeight: 'bold'
  },
  icon: {
    marginRight: height * 0.02
  }
}
```
- [ ] Each button now looks roughly like this (with varying text and icon):
```
<Button
  rounded
  style={styles.button}
  onPress={() => handleSubmit()}
>
<Text style={styles.buttonText}>Continue</Text>
<Feather
  name='arrow-right-circle'
  size={30}
  color='white'
  style={styles.icon}
/>
</Button>
```

### How should this be manually tested?
Pull down and see the more consistent UX!
### Have tests been written for all functionality?
No.
### Any background context you want to provide?
Please let me know if any of the shadows look weird.
### What are the relevant tickets?
Closes #87 
Closes #108 
Closes #109 
Closes #118 
### Screenshots (if appropriate)
<img width="335" alt="Welcome Page" src="https://user-images.githubusercontent.com/31895658/73127882-49866980-3f84-11ea-9495-a1809720f701.png">
<img width="535" alt="Screen Shot 2020-01-25 at 2 55 58 PM" src="https://user-images.githubusercontent.com/31895658/73127962-653e3f80-3f85-11ea-996e-bbcd4318b19e.png">
<img width="535" alt="Screen Shot 2020-01-25 at 2 56 46 PM" src="https://user-images.githubusercontent.com/31895658/73127963-653e3f80-3f85-11ea-8211-0d4faea038ca.png">
<img width="535" alt="Screen Shot 2020-01-25 at 2 59 53 PM" src="https://user-images.githubusercontent.com/31895658/73127964-65d6d600-3f85-11ea-84b4-4da26285c41e.png">
<img width="535" alt="Screen Shot 2020-01-25 at 3 02 03 PM" src="https://user-images.githubusercontent.com/31895658/73127965-65d6d600-3f85-11ea-92d8-2a027bd006fa.png">

### Additional Notes
We still need to figure out a way to subtly tell users that the accordion menus can be expanded.



