### PR TITLE
Refine symptom ui/ux

### DIFF
--- a/screens/Results/Results.js
+++ b/screens/Results/Results.js
@@ -73,8 +73,8 @@ export default function SymptomsQA({ navigation }) {
         {expanded ? (
           <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-up' />
         ) : (
-          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-down' />
-        )}
+            <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-down' />
+          )}
       </View>
     );
   };
@@ -112,8 +112,8 @@ export default function SymptomsQA({ navigation }) {
         />
       </SafeAreaView>
     ) : (
-      <Text>No conflicting evidence</Text>
-    );
+        <Text>No conflicting evidence</Text>
+      );
   };
 
   const createTopDiagnosis = () => {
@@ -299,16 +299,16 @@ const styles = StyleSheet.create({
     width: '100%'
   },
   button: {
-      alignSelf: 'center',
-      height: height * 0.07,
-      justifyContent: 'space-around',
-      marginBottom: height * 0.02,
-      marginTop: -height * 0.25,
-      shadowColor: 'black',
-      shadowOffset: { width: 5, height: 5 },
-      shadowOpacity: 0.3,
-      shadowRadius: 4.65,
-      width: width * 0.65
+    alignSelf: 'center',
+    height: height * 0.07,
+    justifyContent: 'space-around',
+    marginBottom: height * 0.02,
+    marginTop: -height * 0.25,
+    shadowColor: 'black',
+    shadowOffset: { width: 5, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    width: width * 0.65
   },
   buttonText: {
     fontSize: height * 0.025,

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Body, Card, CardItem, Input, Item } from 'native-base';
 import { Entypo, AntDesign, Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -78,7 +78,9 @@ export default function SymptomsScreen({ navigation }) {
   const displaySymptoms = searchResults.map((result, index) => {
     let found = symptoms.find(symptom => symptom.id == result.id);
     return (
-      <View key={index} style={styles.checkboxes}>
+      <TouchableOpacity key={index} style={styles.checkboxes} onPress={() => {
+        findSymptom(result);
+      }}>
         <Text style={styles.symptomText}>{result.common_name}?</Text>
         <AntDesign
           name={found ? 'checkcircle' : 'pluscircleo'}
@@ -86,11 +88,8 @@ export default function SymptomsScreen({ navigation }) {
           style={styles.add}
           size={26}
           color={found ? 'green' : 'black'}
-          onPress={() => {
-            findSymptom(result);
-          }}
         />
-      </View>
+      </TouchableOpacity>
     );
   });
 

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -162,7 +162,7 @@ export default function SymptomsScreen({ navigation }) {
           </Item>
           <Text style={styles.hint}>Select all that apply (at least 3):</Text>
           <ScrollView style={styles.scroll}>
-            <View style={styles.searchResultsContainer}>
+            {symptoms.length ? <View style={styles.searchResultsContainer}>
               <Accordion
                 dataArray={[
                   {
@@ -172,7 +172,8 @@ export default function SymptomsScreen({ navigation }) {
                 renderContent={renderContent}
                 style={styles.accordion}
               />
-            </View>
+            </View> : <View style={styles.searchResultsContainer}>
+              </View>}
             <View style={styles.searchResults}>{displaySymptoms}</View>
           </ScrollView>
           {symptoms.length >= 3 && (

--- a/screens/SearchSymptoms/SearchSymptoms.js
+++ b/screens/SearchSymptoms/SearchSymptoms.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Body, Card, CardItem, Input, Item } from 'native-base';
+import { Dimensions, Icon, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Accordion, Card, CardItem, Input, Item } from 'native-base';
 import { Entypo, AntDesign, Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -20,6 +20,8 @@ export default function SymptomsScreen({ navigation }) {
   } = navigation.state.params;
   const [symptoms, setSymptoms] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
+  const [expanded, setExpanded] = useState({});
+
 
   const searchSymptoms = async text => {
     if (text.length > 2) {
@@ -93,6 +95,43 @@ export default function SymptomsScreen({ navigation }) {
     );
   });
 
+  const renderHeader = (item, expanded) => {
+    return (
+      <View
+        style={{
+          flexDirection: 'row',
+          padding: 10,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: '#0960FF',
+          width: '80%'
+        }}
+      >
+        <Text style={{ fontWeight: '600', color: '#fff' }}> {item.title}</Text>
+        {expanded ? (
+          <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-up' />
+        ) : (
+            <Icon style={{ fontSize: 18, color: '#fff' }} name='arrow-down' />
+          )}
+      </View>
+    );
+  };
+  const renderContent = item => {
+    return (
+      <SafeAreaView
+        style={{
+          flex: 1,
+          height: expanded ? null : 0,
+          overflow: 'hidden'
+        }}
+      >
+        <Card style={styles.selectedContainer}>
+          {displaySelectedSymptoms}
+        </Card>
+      </SafeAreaView>
+    );
+  };
+
   return (
     <View style={styles.container}>
       <LinearGradient
@@ -124,9 +163,15 @@ export default function SymptomsScreen({ navigation }) {
           <Text style={styles.hint}>Select all that apply (at least 3):</Text>
           <ScrollView style={styles.scroll}>
             <View style={styles.searchResultsContainer}>
-              <Card style={styles.selectedContainer}>
-                {displaySelectedSymptoms}
-              </Card>
+              <Accordion
+                dataArray={[
+                  {
+                    title: symptoms.length ? `Selected Symptoms (${symptoms.length})` : `Selected Symptoms`
+                  }
+                ]}
+                renderContent={renderContent}
+                style={styles.accordion}
+              />
             </View>
             <View style={styles.searchResults}>{displaySymptoms}</View>
           </ScrollView>
@@ -169,6 +214,10 @@ const styles = StyleSheet.create({
     marginTop: height * 0.06,
     width: '100%'
   },
+  accordion: {
+    alignSelf: 'center',
+    width: width * 0.90
+  },
   scroll: {
     marginTop: height * 0.01,
     width: '100%'
@@ -189,7 +238,6 @@ const styles = StyleSheet.create({
     paddingTop: height * 0.01
   },
   searchResultsContainer: {
-    marginLeft: '5%',
     width: '100%'
   },
   selectedContainer: {
@@ -204,7 +252,6 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginLeft: height * 0.01,
     marginTop: height * 0.01,
     maxWidth: width * 0.9,
     padding: height * 0.01,


### PR DESCRIPTION
## What does this PR do?
- [x] Adds accordion as drop down to display selected symptoms
- [x] Adds number of symptoms selected on header of accordion
- [x] Click card instead of + button to select

### Where should the reviewer start?

- screens/SearchSymptoms/SearchSymptoms.js

#### How should this be manually tested?

Pull down and open in expo then navigate to select symptoms screen

#### Have tests been written for all functionality?

No

#### What are the relevant tickets?

closes #102 closes #126

#### Screenshots (if appropriate)

<img width="535" alt="Screen Shot 2020-01-27 at 3 34 39 PM" src="https://user-images.githubusercontent.com/25589695/73220489-c435bd00-411b-11ea-9a81-10a664807221.png">
<img width="535" alt="Screen Shot 2020-01-27 at 3 34 42 PM" src="https://user-images.githubusercontent.com/25589695/73220493-c861da80-411b-11ea-9bed-4aad988a4a42.png">